### PR TITLE
Adjust claims page

### DIFF
--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -1,9 +1,11 @@
 <script>
+import ClaimCardBanner from './ClaimCardBanner.svelte'
 import { day } from './const'
 import { goto } from '@roxi/routify'
 import { Card, Button } from '@silintl/ui-components'
 import { isLoadingById } from './progress'
 
+export let claim = {}
 export let item = {}
 export let state = {}
 export let buttons = []
@@ -50,14 +52,7 @@ const checkIfLoading = (id, string = '') => isLoadingById(id) ? 'loading...' : s
 </style>
 
 <Card isClickable noPadding on:click={gotoItem} on:keypress={gotoItem} class="height-fit-content py-0 {$$props.class}">
-  <div class="flex justify-start align-items-center black mb-2 p-1 pl-50px" style="background: var({state.bgColor});">
-    <span class="material-icons" style="color: var({state.color});">{state.icon}</span>
-
-    <div class="mdc-theme--primary pl-10px">
-      <div class="mdc-typography--headline6 multi-line-truncate content" style="color: var({state.color});">{state.title}</div>
-      <div class="multi-line-truncate fs-14" style="color: var({state.color});">{item.message || checkIfLoading(item.id)}</div>
-    </div>
-  </div>
+  <ClaimCardBanner {state} {item} />
 
   <div class="mdc-typography--headline5 multi-line-truncate content ml-50px">
     {item.name || checkIfLoading(item.id)}

--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -41,14 +41,6 @@ const checkIfLoading = (id, string = '') => isLoadingById(id) ? 'loading...' : s
 .ml-50px {
   margin-left: 50px;
 }
-
-.pl-10px {
-  padding-left: 10px;
-}
-
-.pl-50px {
-  padding-left: 50px;
-}
 </style>
 
 <Card isClickable noPadding on:click={gotoItem} on:keypress={gotoItem} class="height-fit-content py-0 {$$props.class}">

--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -1,22 +1,26 @@
 <script>
 import ClaimCardBanner from './ClaimCardBanner.svelte'
 import { day } from './const'
-import { goto } from '@roxi/routify'
 import { Card, Button } from '@silintl/ui-components'
-import { isLoadingById } from './progress'
+import { createEventDispatcher } from 'svelte'
+
+const dispatch = createEventDispatcher()
 
 export let claim = {}
 export let item = {}
-export let state = {}
-export let buttons = []
 
 const now = Date.now()
 
 $: msAgo = now - Date.parse(item.updated_at)
 $: daysAgo = msAgo > 0 ? Math.floor(msAgo/day) : '-'
 
-const gotoItem = () => item.id && $goto(`/requests/${item.id}`)
-const checkIfLoading = (id, string = '') => isLoadingById(id) ? 'loading...' : string
+const editClaim = () => dispatch('edit-claim', claim.id)
+const gotoClaim = () => dispatch('goto-claim', claim.id)
+const onKeyPress = event => {
+  if (event.code === 'Space' || event.code === 'Enter') {
+    gotoClaim()
+  }
+}
 </script>
 
 <style>
@@ -43,29 +47,25 @@ const checkIfLoading = (id, string = '') => isLoadingById(id) ? 'loading...' : s
 }
 </style>
 
-<Card isClickable noPadding on:click={gotoItem} on:keypress={gotoItem} class="height-fit-content py-0 {$$props.class}">
-  <ClaimCardBanner {state} {item} />
+<Card isClickable noPadding on:click={gotoClaim} on:keypress={onKeyPress} class="height-fit-content py-0 {$$props.class}">
+  <ClaimCardBanner {claim} {item} />
 
   <div class="mdc-typography--headline5 multi-line-truncate content ml-50px">
-    {item.name || checkIfLoading(item.id)}
+    {item.name || ''}
   </div>
 
   <div class="content multi-line-truncate ml-50px">
-    {item.accountable_person || checkIfLoading(item.id)}
+    {item.accountable_person || ''}
   </div>
 
   <div class="action pb-2 ml-50px" slot="actions">
-    {#if buttons}
-      {#each buttons as btn}
-        <Button raised url={btn.url}>{btn.label}</Button>
-      {/each}
-    {/if}
+    <Button raised on:click={editClaim}>Edit Claim</Button>
 
     <div class="fs-12 gray mt-1">
       {#if daysAgo}
         Last changed {daysAgo} days ago
       {:else}
-        <div>{checkIfLoading(item.id, 'No changes')}</div>
+        No changes
       {/if}
     </div>
   </div>

--- a/src/components/ClaimCardBanner.svelte
+++ b/src/components/ClaimCardBanner.svelte
@@ -1,0 +1,19 @@
+<script>
+export let item = {}
+export let state = {}
+
+$: bgColor = state.bgColor || ''
+$: color = state.color || ''
+$: icon = state.icon || ''
+$: message = item.message || ''
+$: title = state.title || ''
+</script>
+
+<div class="flex justify-start align-items-center black mb-2 p-1 pl-50px" style="background: var({bgColor});">
+  <span class="material-icons" style="color: var({color});">{icon}</span>
+
+  <div class="mdc-theme--primary pl-10px">
+    <div class="mdc-typography--headline6 multi-line-truncate content" style="color: var({color});">{title}</div>
+    <div class="multi-line-truncate fs-14" style="color: var({color});">{message}</div>
+  </div>
+</div>

--- a/src/components/ClaimCardBanner.svelte
+++ b/src/components/ClaimCardBanner.svelte
@@ -1,6 +1,10 @@
 <script>
+import { getState } from '../data/claims'
+
+export let claim = {}
 export let item = {}
-export let state = {}
+
+$: state = getState(claim)
 
 $: bgColor = state.bgColor || ''
 $: color = state.color || ''

--- a/src/components/ClaimCardBanner.svelte
+++ b/src/components/ClaimCardBanner.svelte
@@ -13,16 +13,6 @@ $: message = item.message || ''
 $: title = state.title || ''
 </script>
 
-<style>
-.pl-10px {
-  padding-left: 10px;
-}
-
-.pl-50px {
-  padding-left: 50px;
-}
-</style>
-
 <div class="flex justify-start align-items-center black mb-2 p-1 pl-50px" style="background: var({bgColor});">
   <span class="material-icons" style="color: var({color});">{icon}</span>
 

--- a/src/components/ClaimCardBanner.svelte
+++ b/src/components/ClaimCardBanner.svelte
@@ -9,6 +9,16 @@ $: message = item.message || ''
 $: title = state.title || ''
 </script>
 
+<style>
+.pl-10px {
+  padding-left: 10px;
+}
+
+.pl-50px {
+  padding-left: 50px;
+}
+</style>
+
 <div class="flex justify-start align-items-center black mb-2 p-1 pl-50px" style="background: var({bgColor});">
   <span class="material-icons" style="color: var({color});">{icon}</span>
 

--- a/src/components/ClaimCards.svelte
+++ b/src/components/ClaimCards.svelte
@@ -2,7 +2,7 @@
 import { ClaimCard } from './index'
 import { getState } from '../data/claims'
 
-export let items
+export let claims
 </script>
 
 <style>

--- a/src/components/ClaimCards.svelte
+++ b/src/components/ClaimCards.svelte
@@ -12,8 +12,8 @@ export let claims
 </style>
 
 <div class="flex justify-start flex-wrap {$$props.class}">
-  {#each claims as claim}
-    {#each (claim.items || []) as item}
+  {#each claims as claim (claim.id) }
+    {#each (claim.items || []) as item (item.id) }
       <div class="card">
         <ClaimCard {claim} {item} on:edit-claim on:goto-claim />
       </div>

--- a/src/components/ClaimCards.svelte
+++ b/src/components/ClaimCards.svelte
@@ -1,22 +1,22 @@
 <script>
 import { ClaimCard } from './index'
-import { getState } from '../data/claims'
 
 export let claims
 </script>
 
 <style>
-
-.cards {
+.card {
   margin: 8px 8px 8px 0;
   flex-basis: 330px;
 }
 </style>
 
 <div class="flex justify-start flex-wrap {$$props.class}">
-  {#each items as item}
-    <div class="cards">
-      <ClaimCard state={ getState(item) } {item} buttons={[ { label: "Edit coverage", url: "/items/edit-coverage" } ]} />
-    </div>
+  {#each claims as claim}
+    {#each (claim.items || []) as item}
+      <div class="card">
+        <ClaimCard {claim} {item} on:edit-claim on:goto-claim />
+      </div>
+    {/each}
   {/each}
 </div>

--- a/src/data/claims.js
+++ b/src/data/claims.js
@@ -159,4 +159,4 @@ export async function loadClaims() {
   initialized.set(true)
 }
 
-export const getState = item => states[item.state || 'message']
+export const getState = claim => states[claim.status || 'message']

--- a/src/pages/claims.svelte
+++ b/src/pages/claims.svelte
@@ -13,7 +13,7 @@ $: $initialized || loadClaims()
 
   <Row cols={'12'}>
     {#if $claims.length}
-      <ClaimCards items={$claims} />
+      <ClaimCards claims={$claims} />
     {:else}
       No claims at this time.
     {/if}

--- a/src/pages/claims.svelte
+++ b/src/pages/claims.svelte
@@ -2,8 +2,18 @@
 import { claims, initialized, loadClaims } from '../data/claims.js'
 import { ClaimCards, Row } from '../components/'
 import { Page, Button } from '@silintl/ui-components'
+import { goto } from '@roxi/routify'
 
 $: $initialized || loadClaims()
+
+const onEditClaim = event => {
+  const claimId = event.detail
+  $goto(`/claims/${claimId}/edit`)
+}
+const onGotoClaim = event => {
+  const claimId = event.detail
+  $goto(`/claims/${claimId}`)
+}
 </script>
 
 <Page layout="grid">
@@ -13,7 +23,7 @@ $: $initialized || loadClaims()
 
   <Row cols={'12'}>
     {#if $claims.length}
-      <ClaimCards claims={$claims} />
+      <ClaimCards claims={$claims} on:edit-claim={onEditClaim} on:goto-claim={onGotoClaim} />
     {:else}
       No claims at this time.
     {/if}

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -77,7 +77,7 @@ const handleMoreVertClick = id => {
 
 <Page loading={isLoadingById($user.policy_id)} layout="grid">   
   <Row cols={'12'}>
-    <ClaimCards items={$claims} />
+    <ClaimCards claims={$claims} />
   </Row>
 
   <Row cols={'12'}>

--- a/src/pages/items/[itemId]/new-claim.svelte
+++ b/src/pages/items/[itemId]/new-claim.svelte
@@ -78,7 +78,7 @@ let items
 let item
 
 $: $user.policy_id && loadItems($user.policy_id)
-$: items = itemsByPolicyId[$user.policy_id] || []
+$: items = $itemsByPolicyId[$user.policy_id] || []
 $: item = items.find(itm => itm.id === itemId) || {}
 
 // TODO: get accountable person from item 

--- a/src/pages/items/[itemId]/new-claim.svelte
+++ b/src/pages/items/[itemId]/new-claim.svelte
@@ -134,7 +134,7 @@ const unSetRepairCost = () => {
 <!--TODO: add transitions but not after submit-->
 {#if items && $initialized && claimExists}
   Claim already exists!
-{:else if items && !item}
+{:else if items && !item.id}
   Item does not exist!
 {:else if items && $initialized}
   <Page>


### PR DESCRIPTION
### Added
- Extract ClaimCardBanner component (for banner at top of ClaimCard)

### Fixed
- Update getState() to use a claim's status (untested)
- Fix retrieval of items on new-claim page
- Update new-claim page's check for whether an item was found

### Changed
- Pass the list of claims (not items) into the ClaimCards component
- Show a ClaimCard for each item on each claim, not just for each claim
- Change ClaimCard(s) to dispatch events rather than calling `$goto`, since they're just components
- Update "claims" page to listen for events and handle URL changes, since it's a page

---

We're waiting on some changes on the API (returning the list of items with the claim's data), so I haven't fully tested this, but it seems to build successfully and work as far as I can manually test.