### PR TITLE
added Needs_initial_changes Theft claim view

### DIFF
--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -19,7 +19,7 @@ $: items = $itemsByPolicyId[policyId] || []
 $: item = items.find(i => i.id = claimItem.item_id) || {}
 $: msAgo = now - Date.parse(claimItem.updated_at)
 $: daysAgo = msAgo > 0 ? Math.floor(msAgo/day) : '-'
-$: state = claim.status && getState(claim.status) || {}
+$: state = getState(claim.status) || {}
 
 const editClaim = () => dispatch('edit-claim', claim.id)
 const gotoClaim = () => dispatch('goto-claim', claim.id)

--- a/src/components/dates.js
+++ b/src/components/dates.js
@@ -1,7 +1,7 @@
-export const formatDate = (dateString, ...others) => {
+export const formatDate = dateString => {
     if (dateString) {
       const date = new Date(dateString)
-      return date.toLocaleDateString(...others)
+      return date.toLocaleDateString("default", {month: 'long', day: 'numeric', year: 'numeric'})
     }
     return ''
   }

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -9,7 +9,7 @@ export async function UPDATE(uri, body) { return await customFetch('put'   , uri
 export async function DELETE(uri      ) { return await customFetch('delete', uri      ) }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData
-export const upload = async formData => await CREATE('post', formData)
+export const upload = async formData => await CREATE('upload', formData)
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Supplying_request_options
 async function customFetch(method, uri, body) {

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -1,11 +1,17 @@
 <script>
 import user from '../../authn/user.js'
 import { Banner, MoneyInput, Row, ClaimBanner } from '../../components'
+import { formatDate } from '../../components/dates.js'
 import { loadClaims, claims, initialized } from '../../data/claims'
 import { loadItems, itemsByPolicyId } from '../../data/items'
 import { goto, params } from '@roxi/routify'
-import { Button, Page } from '@silintl/ui-components'
-import { formatDate } from '../../components/dates.js'
+import { Button, Form, Page } from '@silintl/ui-components'
+
+const formData = new FormData()
+
+let file = {}
+let replacementCost
+let uploading = false
 
 $: ! $initialized && loadClaims()
 
@@ -17,11 +23,34 @@ $: item = items.find(itm => itm.id === claimItem.item_id) || {}
 $: eventDate = formatDate(claim.event_date)
 
 const onClick = () => $goto(`claims/${$params.claimId}/edit)`)
+
+const onSubmit = () => {
+  formData.append('replacement_cost', replacementCost)
+  
+  console.log(formData) //TODO update claim with replacementCost and file to api
+}
+
+async function chosen(event) {
+  formData.append('file', event.target.files[0])
+
+  try {
+    uploading = true
+
+    // file = await upload(formData) //Todo verify the backend will upload files with this method
+
+  } finally {
+    uploading = false
+  }
+}
 </script>
 
 <style>
 .left-detail {
   margin: 0.5rem 0;
+}
+
+.label {
+  color: hsla(219, 53%, 7%, .6);
 }
 
 </style>
@@ -47,15 +76,32 @@ const onClick = () => $goto(`claims/${$params.claimId}/edit)`)
       {item.coverage_amount  || ''}
     </p>
     <p>
-      <b>Maximum payout</b><br />
+      <b>Maximum payout (if approved)</b><br />
       <!-- TODO get the actual maximum amount -->
       {(item.coverage_amount * .7)  || ''}
     </p>
     <p>
       <Button on:click={onClick} outlined>Edit claim</Button>
     </p>
-    <p>
-      <MoneyInput label="Actual cost of replacement"></MoneyInput>
-    </p>
+    {#if claim.status === 'Needs_initial_changes' && claim.event_type === 'Theft'}
+      <Form on:submit={onSubmit}>
+        <MoneyInput bind:value={replacementCost} label="Actual cost of replacement" />
+
+        <p class="label ml-1 mt-6px">
+          To convert to USD, <a class="label" href="https://www.google.com/search?q=currency+converter">use this converter.</a>
+        </p>
+
+        <label for="receipt" class="ml-1">Attach replacement item receipt</label>
+
+        <br/>
+
+        <!-- TODO find a file drop component to replace this -->
+        <input id="receipt" type="file" accept="application/pdf,image/*" on:change={chosen} />
+
+        <br/>
+
+        <Button raised>Upload Receipt</Button>
+      </Form>
+    {/if}
   </Row>
 </Page>

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -24,7 +24,7 @@ $: item = items.find(itm => itm.id === claimItem.item_id) || {}
 $: eventDate = formatDate(claim.event_date)
 $: needsInitialChangesAndReplacement = claim.status === 'Needs_initial_changes' && claim.event_type === 'Theft'
 
-const onClick = () => $goto(`claims/${$params.claimId}/edit)`)
+const editClaim = () => $goto(`claims/${$params.claimId}/edit)`)
 
 const onSubmit = () => {
   const cents = replacementCost * 100
@@ -85,7 +85,7 @@ async function chosen(event) {
       {(item.coverage_amount * .7)  || ''}
     </p>
     <p>
-      <Button on:click={onClick} outlined>Edit claim</Button>
+      <Button on:click={editClaim} outlined>Edit claim</Button>
     </p>
     {#if needsInitialChangesAndReplacement}
       <Form on:submit={onSubmit}>

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -21,7 +21,7 @@ $: items = $itemsByPolicyId[$user.policy_id] || []
 $: ! items.length && loadItems($user.policy_id)
 $: item = items.find(itm => itm.id === claimItem.item_id) || {}
 $: eventDate = formatDate(claim.event_date)
-$: needsInitialChangesAndReplacement = claim.status === 'Draft' && claim.event_type === 'Theft' //TODO instead of event_type this will need to allow all replacements
+$: needsInitialChangesAndReplacement = claim.status === 'Needs_initial_changes' && claim.event_type === 'Theft' //TODOinstead of event_type this will need to allow all replacements
 
 const editClaim = () => $goto(`claims/${$params.claimId}/edit)`)
 

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -21,6 +21,7 @@ $: items = $itemsByPolicyId[$user.policy_id] || []
 $: ! items.length && loadItems($user.policy_id)
 $: item = items.find(itm => itm.id === claimItem.item_id) || {}
 $: eventDate = formatDate(claim.event_date)
+$: needsInitialChangesAndReplacement = claim.status === 'Needs_initial_changes' && claim.event_type === 'Theft'
 
 const onClick = () => $goto(`claims/${$params.claimId}/edit)`)
 
@@ -83,7 +84,7 @@ async function chosen(event) {
     <p>
       <Button on:click={onClick} outlined>Edit claim</Button>
     </p>
-    {#if claim.status === 'Needs_initial_changes' && claim.event_type === 'Theft'}
+    {#if needsInitialChangesAndReplacement}
       <Form on:submit={onSubmit}>
         <MoneyInput bind:value={replacementCost} label="Actual cost of replacement" />
 

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -14,7 +14,7 @@ $: claimItem = claim.claim_items?.[0] || {} //For now there will only be one cla
 $: items = $itemsByPolicyId[$user.policy_id] || []
 $: ! items.length && loadItems($user.policy_id)
 $: item = items.find(itm => itm.id === claimItem.item_id) || {}
-$: eventDate = formatDate(claim.event_date, "default", {month: 'long', day: 'numeric', year: 'numeric'})
+$: eventDate = formatDate(claim.event_date)
 
 const onClick = () => $goto(`claims/${$params.claimId}/edit)`)
 </script>

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -2,6 +2,7 @@
 import user from '../../authn/user.js'
 import { Banner, MoneyInput, Row, ClaimBanner } from '../../components'
 import { formatDate } from '../../components/dates.js'
+import { upload } from '../../data'
 import { loadClaims, claims, initialized } from '../../data/claims'
 import { loadItems, itemsByPolicyId } from '../../data/items'
 import { goto, params } from '@roxi/routify'
@@ -26,7 +27,9 @@ $: needsInitialChangesAndReplacement = claim.status === 'Needs_initial_changes' 
 const onClick = () => $goto(`claims/${$params.claimId}/edit)`)
 
 const onSubmit = () => {
-  formData.append('replacement_cost', replacementCost)
+  const cents = replacementCost * 100
+
+  formData.append('replacement_cost', cents)
   
   console.log(formData) //TODO update claim with replacementCost and file to api
 }
@@ -37,7 +40,7 @@ async function chosen(event) {
   try {
     uploading = true
 
-    // file = await upload(formData) //Todo verify the backend will upload files with this method
+    file = await upload(formData) //Todo verify the backend will upload files with this method
 
   } finally {
     uploading = false

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -8,9 +8,8 @@ import { loadItems, itemsByPolicyId } from '../../data/items'
 import { goto, params } from '@roxi/routify'
 import { Button, Form, Page } from '@silintl/ui-components'
 
-const formData = new FormData()
+const updatedClaimData = {}
 
-let file = {}
 let replacementCost
 let uploading = false
 
@@ -29,19 +28,20 @@ const editClaim = () => $goto(`claims/${$params.claimId}/edit)`)
 const onSubmit = () => {
   const cents = replacementCost * 100
 
-  formData.append('replacement_cost', cents)
+  updatedClaimData.replacement_cost = cents
   
-  console.log(formData) //TODO update claim with replacementCost and file to api
+  console.log(updatedClaimData) //TODO update claim with replacementCost and file to api
 }
 
 async function chosen(event) {
+  const formData = new FormData()
+
   formData.append('file', event.target.files[0])
 
   try {
     uploading = true
 
-    file = await upload(formData) //Todo verify the backend will upload files with this method
-
+    updatedClaimData.file = await upload(formData)
   } finally {
     uploading = false
   }

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -21,7 +21,7 @@ $: items = $itemsByPolicyId[$user.policy_id] || []
 $: ! items.length && loadItems($user.policy_id)
 $: item = items.find(itm => itm.id === claimItem.item_id) || {}
 $: eventDate = formatDate(claim.event_date)
-$: needsInitialChangesAndReplacement = claim.status === 'Needs_initial_changes' && claim.event_type === 'Theft'
+$: needsInitialChangesAndReplacement = claim.status === 'Draft' && claim.event_type === 'Theft' //TODO instead of event_type this will need to allow all replacements
 
 const editClaim = () => $goto(`claims/${$params.claimId}/edit)`)
 


### PR DESCRIPTION
Added a form to upload receipt and replacement cost for status of Needs_initial_changes and event_type of theft.
This will also likely be used for other replacement views, but we need information from the api to know if it is a replacement.
Since there isn't working endpoint to this yet it will need to be finished later