### PR TITLE
update affiliate organization

### DIFF
--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -151,18 +151,20 @@ const isYou = householdMember => householdMember.id === $user.id
   <p>
     <TextField placeholder={'1234567'} autofocus bind:value={householdId} on:blur={updateHouseholdId} />
   </p>
-  
-  <h3 class="ml-1 mt-3" >Affiliation<span class="required">*</span></h3>
-  <label class="custom-field">
-    <input class="fs-14" list="affiliations" name="affiliations-choice" placeholder="&nbsp;" bind:value={affiliationChoice} on:change={updateAffiliation}/>
-    <span class="placeholder">Your entity of affiliation</span>
-  </label>
 
-  <datalist id="affiliations">
-    {#each Object.values(affiliations) as affiliation}
-      <option value={affiliation}>  
-    {/each}
-  </datalist>
+  {#if policy.type === 'Corporate'}
+    <h3 class="ml-1 mt-3" >Affiliation<span class="required">*</span></h3>
+    <label class="custom-field">
+      <input class="fs-14" list="affiliations" name="affiliations-choice" placeholder="&nbsp;" bind:value={affiliationChoice} on:change={updateAffiliation}/>
+      <span class="placeholder">Your entity of affiliation</span>
+    </label>
+
+    <datalist id="affiliations">
+      {#each Object.values(affiliations) as affiliation}
+        <option value={affiliation}>  
+      {/each}
+    </datalist>
+  {/if}
   
   <h3 class="mt-3">Accountable people</h3>
 

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -49,7 +49,7 @@ const updateHouseholdId = async () => {
 
 const updateAffiliation = async () => {
   for (const [key, value] of Object.entries(affiliations)){
-    if(affiliationChoice === value && affiliationChoice !== policyData.entity_code) {
+    if(affiliationChoice === value && key !== policyData.entity_code) {
 
       policyData.entity_code = key
 

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -21,14 +21,14 @@ $: dependents = $dependentsByPolicyId[policyId] || []
 $: householdMembers = $membersByPolicyId[policyId] || []
 $: $policies.length || init()
 $: policy = $policies.find(policy => policy.id === policyId) || {}
-$: policy.household_id && setPolicyHouseholdId()
+$: policy.household_id && setPolicyHouseholdId(policy.household_id)
 
-const setPolicyHouseholdId = () => householdId = policy.household_id || ''
+const setPolicyHouseholdId = id => householdId = id || ''
 
 const updateHouseholdId = async () => {
   householdId = householdId.replaceAll(' ', '')
   if(householdId !== policy.household_id) {
-    if(validateId(householdId)) {
+    if(isIdValid(householdId)) {
       policyData.household_id = householdId
     
       await updatePolicy(policyId, policyData)
@@ -40,7 +40,7 @@ const updateHouseholdId = async () => {
   }
 }
 
-const validateId = sanitizedId => sanitizedId.length && sanitizedId.split('').every(digit => /[0-9]/.test(digit))
+const isIdValid = sanitizedId => sanitizedId.length && sanitizedId.split('').every(digit => /[0-9]/.test(digit))
 const edit = id => $goto(`/household/settings/dependent/${id}`)
 const isYou = householdMember => householdMember.id === $user.id
 </script>

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -21,9 +21,9 @@ $: dependents = $dependentsByPolicyId[policyId] || []
 $: householdMembers = $membersByPolicyId[policyId] || []
 $: $policies.length || init()
 $: policy = $policies.find(policy => policy.id === policyId) || {}
-$: policy.household_id && setPolicyHouseholdId(policy.household_id)
+$: policy.household_id && setPolicyHouseholdId()
 
-const setPolicyHouseholdId = id => householdId = id || ''
+const setPolicyHouseholdId = () => householdId = policy.household_id || ''
 
 const updateHouseholdId = async () => {
   householdId = householdId.replaceAll(' ', '')

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -99,7 +99,6 @@ const isYou = householdMember => householdMember.id === $user.id
   color: var(--mdc-theme-status-error);
 }
 
-
 /* datalist styling */
 *, *::before, *::after {
   box-sizing: border-box;

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -98,6 +98,50 @@ const isYou = householdMember => householdMember.id === $user.id
 .required {
   color: var(--mdc-theme-status-error);
 }
+
+
+/* datalist styling */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+.custom-field {
+  font-size: 14px;
+  position: relative;
+  --field-padding: 12px;
+  border-top: 20px solid transparent;
+}
+
+.custom-field input {
+  border-radius: 8px;
+  border: 1px solid gray;
+  width: 240px;
+  padding: var(--field-padding) 0 var(--field-padding) var(--field-padding);
+}
+
+.custom-field .placeholder {
+  position: absolute;
+  bottom: -45px;
+  top: 22px;  
+  transform: translateY(-50%);
+  color: #aaa;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  left: var(--field-padding);
+  width: calc(100% - (var(--field-padding) * 2));
+  transition: 
+    top 0.3s ease,
+    color 0.3s ease,
+    font-size 0.3s ease;
+}
+
+.custom-field input:not(:placeholder-shown) + .placeholder,
+.custom-field input:focus + .placeholder {
+  top: 4px;
+  font-size: 10px;
+  color: #222;
+}
 </style>
 
 <Page>
@@ -108,9 +152,10 @@ const isYou = householdMember => householdMember.id === $user.id
     <TextField placeholder={'1234567'} autofocus bind:value={householdId} on:blur={updateHouseholdId} />
   </p>
   
-  <label>
-    <h3 class="ml-1 mt-3" >Affiliation<span class="required">*</span></h3>
-    <input list="affiliations" name="affiliations-choice" bind:value={affiliationChoice} on:change={updateAffiliation}/>
+  <h3 class="ml-1 mt-3" >Affiliation<span class="required">*</span></h3>
+  <label class="custom-field">
+    <input class="fs-14" list="affiliations" name="affiliations-choice" placeholder="&nbsp;" bind:value={affiliationChoice} on:change={updateAffiliation}/>
+    <span class="placeholder">Your entity of affiliation</span>
   </label>
 
   <datalist id="affiliations">

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -10,6 +10,7 @@ import { Button, TextField, IconButton, Page, Snackbar, setNotice } from "@silin
 const policyData = {}
 
 let householdId = ''
+let affiliation = ''
 
 $: policyId = $user.policy_id
 $: if (policyId) {
@@ -81,6 +82,11 @@ const isYou = householdMember => householdMember.id === $user.id
   <h3 class="ml-1 mt-3">Household ID<span class="required">*</span></h3>
   <p>
     <TextField placeholder={'1234567'} autofocus bind:value={householdId} on:blur={updateHouseholdId} />
+  </p>
+  
+  <h3 class="ml-1 mt-3">Affiliation<span class="required">*</span></h3>
+  <p>
+    <TextField placeholder={'Wycliffe USA, SIL International'} autofocus bind:value={affiliation} on:blur={updateHouseholdId} />
   </p>
   
   <h3 class="mt-3">Accountable people</h3>


### PR DESCRIPTION
Added:
- `<datalist>` for Affiliate organizaiton (like select but searchable)
- styling for the input
- function for updating policies.entity_code
- control block for the affiliatiton field

I will be putting the datalist element into a component next, but wanted to see if it served our purposes first.

![image](https://user-images.githubusercontent.com/70765247/131581711-449a5b09-180e-42a9-845f-05c355a2000f.png)
