### PR TITLE
Fix `updateClaim()`

### DIFF
--- a/src/data/claims.js
+++ b/src/data/claims.js
@@ -116,11 +116,11 @@ export async function getClaim(itemId) {
  *
  * @description a function to update a claim
  * @export
- * @param {String} itemId
+ * @param {String} claimId
  * @param {Object} newClaimData
  */
-export async function updateClaim(itemId, newClaimData) {
-  start(itemId)
+export async function updateClaim(claimId, newClaimData) {
+  start(claimId)
 
   //TODO make sure these properties are what is used in update claim form when it exists
   const parsedData = {
@@ -129,15 +129,15 @@ export async function updateClaim(itemId, newClaimData) {
     event_description: newClaimData.event_description,
   }
 
-  const updatedClaim = await UPDATE(`claims/${itemId}`, parsedData)
+  const updatedClaim = await UPDATE(`claims/${claimId}`, parsedData)
 
   claims.update(currClaims => {
-    let i = currClaims.findIndex(clm => clm.itemId === itemId)
+    let i = currClaims.findIndex(clm => clm.id === claimId)
     currClaims[i] = updatedClaim
     return currClaims
   })
 
-  stop(itemId)
+  stop(claimId)
 
   return updatedClaim
 }

--- a/src/pages/claims/[claimId]/edit.svelte
+++ b/src/pages/claims/[claimId]/edit.svelte
@@ -38,7 +38,7 @@ $: items = $itemsByPolicyId[$user.policy_id] || []
 $: item = items.find(anItem => anItem.id === itemId) || {}
 
 const onSubmit = async event => {
-  await updateClaim(itemId, event.detail)
+  await updateClaim(claimId, event.detail)
   $goto(`/claims/${claimId}`)
 }
 </script>


### PR DESCRIPTION
### Fixed
- Fix `updateClaim()` function to use "claimId", not "itemId"

---

I don't think this was in use (much) yet, but while it had my attention I went and and made the change.