### PR TITLE
update a claim with receipts

### DIFF
--- a/src/components/FileDropArea/FileDropArea.svelte
+++ b/src/components/FileDropArea/FileDropArea.svelte
@@ -52,7 +52,7 @@ function previewFile(file) {
   reader.readAsDataURL(file)
   reader.onloadend = function() {
     let img = document.createElement('img')
-    img.style = "width: -webkit-fill-available; margin-bottom: 10px ;margin-right: 10px;vertical-align: middle;"
+    img.style = "max-width: 200px; margin-bottom: 10px ;margin-right: 10px;vertical-align: middle;"
     img.src = reader.result
     document.getElementById('gallery').appendChild(img)
   }

--- a/src/components/FileDropArea/FileDropArea.svelte
+++ b/src/components/FileDropArea/FileDropArea.svelte
@@ -5,6 +5,7 @@ import { createEventDispatcher } from "svelte"
 export let raised = false
 export let outlined = false
 export let uploading = false
+export let showPreview = true
 
 let fileInput = {}
 
@@ -99,7 +100,9 @@ form {
     <div>or drop files here</div>
     <i class="material-icons icon" id="upload-icon">cloud_upload</i>
   </form>
-  <div id="gallery" class="mt-10px"></div>
+  {#if showPreview}
+    <div id="gallery" class="mt-10px"></div>
+  {/if}
   {#if uploading}
     <Progress.Circular />
     <span>{`Uploading file`}</span>

--- a/src/data/claims.js
+++ b/src/data/claims.js
@@ -142,6 +142,14 @@ export async function updateClaim(itemId, newClaimData) {
   return updatedClaim
 }
 
+export async function claimsFileAttach(claimId, fileId) {
+  start(fileId)
+
+  await CREATE(`claims/${claimId}/files`, { "file_id": fileId })
+
+  stop(fileId)
+}
+
 /**
  *
  * @description a function to delete a claim

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -76,7 +76,8 @@ const onSubmit = async () => {
   }
 
   for (let i = 0; i < files.length; i++) {
-    await claimsFileAttach(claimId, files[i].id)
+    const file = await upload(files[i])
+    await claimsFileAttach(claimId, file.id)
   }
 
   files = []
@@ -93,10 +94,10 @@ async function onUpload(event) {
 
     showPreview = true
 
-    const file = await upload(event.detail)
+    const file = event.detail
 
     files = [...files, file]
-
+    
   } finally {
     uploading = false
   }
@@ -161,7 +162,7 @@ async function onUpload(event) {
     <p>
       <Button on:click={editClaim} outlined>Edit claim</Button>
     </p>
-    {#if needsReceipt}
+    {#if needsReceipt || true}
       <Form on:submit={onSubmit}>
         <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} />
 

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -36,7 +36,7 @@ $: needsReceipt = (needsRepairReceipt || needsReplaceReceipt)
 $: moneyFormLabel = needsRepairReceipt ? "Actual cost of repair" : "Actual cost of replacement"
 $: receiptType = needsRepairReceipt ? 'repair' : 'replacement'
 $: claimFiles = claim.claim_files || []
-$: setShowImgTrue(claimFiles.length)
+$: showImages(claimFiles.length)
 $: if(payoutOption === 'repair') {
     maximumPayout = computeRepairMaxPayout()
   } else if(payoutOption === 'replacement') {
@@ -57,7 +57,7 @@ const computeCashMaxPayout = () => computePayout(claimItem.coverage_amount, clai
 
 const editClaim = () => $goto(`claims/${claimId}/edit)`)
 
-const setShowImgTrue = length => {
+const showImages = length => {
   for (let i = 0; i < length; i++) {
     showImg[i] = true
   }

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -161,7 +161,7 @@ async function onUpload(event) {
     <p>
       <Button on:click={editClaim} outlined>Edit claim</Button>
     </p>
-    {#if needsReceipt || true}
+    {#if needsReceipt}
       <Form on:submit={onSubmit}>
         <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} />
 

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -162,7 +162,7 @@ async function onUpload(event) {
     <p>
       <Button on:click={editClaim} outlined>Edit claim</Button>
     </p>
-    {#if needsReceipt || true}
+    {#if needsReceipt}
       <Form on:submit={onSubmit}>
         <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} />
 

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -76,8 +76,7 @@ const onSubmit = async () => {
   }
 
   for (let i = 0; i < files.length; i++) {
-    const file = await upload(files[i])
-    await claimsFileAttach(claimId, file.id)
+    await claimsFileAttach(claimId, files[i].id)
   }
 
   files = []
@@ -94,7 +93,7 @@ async function onUpload(event) {
 
     showPreview = true
 
-    const file = event.detail
+    const file = await upload(event.detail)
 
     files = [...files, file]
     

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -10,7 +10,7 @@ import { Button, Form, Page } from '@silintl/ui-components'
 
 export let claimId
 
-const updatedClaimData = {}
+const updatedClaimItemData = {}
 const showImg = []
 
 let repairOrReplacementCost
@@ -68,11 +68,11 @@ const onImgError = id => showImg[id] = false
 const onSubmit = async () => {
   const cents = repairOrReplacementCost * 100
 
-  //TODO update this when the claimUpdate payload is defined
+  //TODO update this when the claimItemUpdate endpoint is finished
   if (needsRepairReceipt) {
-    updatedClaimData.repair_actual = cents
+    updatedClaimItemData.repair_actual = cents
   } else if (needsReplaceReceipt) {
-    updatedClaimData.replace_actual = cents
+    updatedClaimItemData.replace_actual = cents
   }
 
   for (let i = 0; i < files.length; i++) {
@@ -83,9 +83,9 @@ const onSubmit = async () => {
   files = []
   showPreview = false
 
-  await loadClaims() //TODO delte this once the updateClaim call is finished
+  await loadClaims()
 
-  console.log(updatedClaimData) //TODO update claim with repairOrReplacementCost and file to api
+  console.log(updatedClaimItemData) //TODO update claimItem with repairOrReplacementCost
 }
 
 async function onUpload(event) {


### PR DESCRIPTION
# Added
- claimsFileAttach
# Changed
- call claimsFileAttach from [ClaimsID]
- reset files after uploading
- remove preview from the FileDropArea after uploading
- show receipts on a claim
![uploadReceipt](https://user-images.githubusercontent.com/70765247/131874430-f0cef6bd-f5d4-4e01-b8d3-89b380e2b2bb.gif)
