### PR TITLE
Previews are uploaded receipts

### DIFF
--- a/src/components/FileDropArea/FileDropArea.svelte
+++ b/src/components/FileDropArea/FileDropArea.svelte
@@ -69,19 +69,17 @@ form > * {
 }
 </style>
 
-<div class="{$$props.class}">
-  <div id="drop-area" class="br-8px" class:highlighted
-    on:dragenter|preventDefault|stopPropagation={highlight}
-    on:dragleave|preventDefault|stopPropagation={unhighlight}
-    on:dragover|preventDefault|stopPropagation={highlight}
-    on:drop|preventDefault|stopPropagation={handleDrop}>
-    <form class="flex justify-between align-items-center my-1 px-1">
-      {#if ! uploading}
-        <input bind:this={fileInput} type="file" id="fileElem" multiple accept={mimeType} disabled={uploading} on:change={() => handleFiles(fileInput.files)}>
-      {/if}
-      <label class="mdc-button mt-1" for="fileElem" class:custom-text-button={raised} class:mdc-button--outlined={outlined} class:disabled={uploading} class:mdc-button--raised={raised}>Choose files</label>
-      <div>or drop files here</div>
-      <i class="material-icons icon" id="upload-icon">cloud_upload</i>
-    </form>
-  </div>
+<div id="drop-area" class="br-8px {$$props.class}" class:highlighted
+  on:dragenter|preventDefault|stopPropagation={highlight}
+  on:dragleave|preventDefault|stopPropagation={unhighlight}
+  on:dragover|preventDefault|stopPropagation={highlight}
+  on:drop|preventDefault|stopPropagation={handleDrop}>
+  <form class="flex justify-between align-items-center my-1 px-1">
+    {#if ! uploading}
+      <input bind:this={fileInput} type="file" id="fileElem" multiple accept={mimeType} disabled={uploading} on:change={() => handleFiles(fileInput.files)}>
+    {/if}
+    <label class="mdc-button mt-1" for="fileElem" class:custom-text-button={raised} class:mdc-button--outlined={outlined} class:disabled={uploading} class:mdc-button--raised={raised}>Choose files</label>
+    <div>or drop files here</div>
+    <i class="material-icons icon" id="upload-icon">cloud_upload</i>
+  </form>
 </div>

--- a/src/components/FileDropArea/FileDropArea.svelte
+++ b/src/components/FileDropArea/FileDropArea.svelte
@@ -1,18 +1,12 @@
 <script>
-import { Button, Progress } from "@silintl/ui-components"
-import { generateRandomID } from "@silintl/ui-components/random"
 import { createEventDispatcher } from "svelte"
-import { flip } from 'svelte/animate'
-import { fly } from 'svelte/transition'
 
 export let raised = false
 export let outlined = false
 export let uploading = false
-export let showPreview = true
 export let mimeType = 'application/pdf,image/*'
 
 let fileInput = {}
-let previews = []
 
 let highlighted = false
 
@@ -39,41 +33,16 @@ function handleFiles(files) {
   if(! uploading) {
     uploading = true
     files = [...files]  //turns files into an array so forEach works
-    files.forEach(file => {
-      const id = generateRandomID()
-      uploadFile(file, id)
-      previewFile(file, id)
-    })
+    files.forEach(uploadFile)
   }
 }
 
-function uploadFile(file, id) {
+function uploadFile(file) {
   const formData = new FormData()
 
   formData.append('file', file)
 
-  dispatch('upload', {formData, id})
-}
-
-function previewFile(file, id) {
-  const reader = new FileReader()
-  reader.readAsDataURL(file)
-  reader.onloadend = function() {
-    const preview = {
-      src: reader.result,
-      name: file.name,
-      id
-    }
-    previews = [...previews, preview]
-  }
-}
-
-function onDelete(event, id) {
-  event.preventDefault()
-
-  previews = previews.filter(preview => preview.id != id)
-
-  dispatch('deleted', id)
+  dispatch('upload', formData)
 }
 
 </script>
@@ -98,13 +67,6 @@ form > * {
 .icon {
   color: hsla(213, 6%, 55%, 1);
 }
-.preview {
-  background-color: hsla(213, 26%, 23%, 1);
-}
-.preview img {
-  max-width: 50px;
-  vertical-align: middle;
-}
 </style>
 
 <div class="{$$props.class}">
@@ -122,19 +84,4 @@ form > * {
       <i class="material-icons icon" id="upload-icon">cloud_upload</i>
     </form>
   </div>
-
-  {#if showPreview}
-    <div class="mt-10px py-10px">
-      {#each previews as preview (preview.id)}
-        <div transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
-          <img class="br-8px mr-10px" src={preview.src} alt={'receipt'} />
-          <p class="white">{preview.name}</p>
-          <Button class="delete-button" raised on:click={evt => onDelete(evt, preview.id)}>Delete</Button>
-        </div>
-      {/each}
-      {#if uploading}
-        <Progress.Circular />
-      {/if}
-    </div>
-  {/if}
 </div>

--- a/src/components/FileDropArea/_index.scss
+++ b/src/components/FileDropArea/_index.scss
@@ -5,11 +5,3 @@
   
   @include button.ink-color(hsla(0, 0%, 100%, 1));
 }
-
-.delete-button {
-  --mdc-theme-primary: hsla(213, 26%, 23%, 1);
-  
-  @include button.ink-color(hsla(0, 0%, 100%, 1));
-
-  border: 2px solid white;
-}

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -1,4 +1,5 @@
 <script>
+import { formatDate } from '../dates'
 import { Button, Progress } from '@silintl/ui-components'
 import { createEventDispatcher } from "svelte"
 import { flip } from 'svelte/animate'
@@ -25,10 +26,9 @@ function onDelete(event, id) {
 <div class="mt-10px py-10px">
   {#each previews as preview (preview.id)}
     <div transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
-      <!-- <img class="br-8px mr-10px" src={preview.src} alt={'receipt'} /> -->
       <div>
         <p class="white my-0">{preview.file.name}</p>
-        <p class="white my-0">{preview.created_at}</p>
+        <p class="white my-0">{formatDate(preview.created_at)}</p>
       </div>
       <Button class="delete-button" raised on:click={evt => onDelete(evt, preview.id)}>Delete</Button>
     </div>

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -14,6 +14,7 @@ const onClick = id => dispatch('preview', id)
 
 function onDelete(event, id) {
   event.preventDefault()
+  event.stopPropagation()
 
   dispatch('deleted', id)
 }

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -1,10 +1,13 @@
 <script>
 import { Button, Progress } from '@silintl/ui-components'
+import { createEventDispatcher } from "svelte"
 import { flip } from 'svelte/animate'
 import { fly } from 'svelte/transition'
 
 export let previews = []
 export let uploading = false
+
+const dispatch = createEventDispatcher()
 
 function onDelete(event, id) {
   event.preventDefault()

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -27,8 +27,8 @@ function onDelete(event, id) {
     <div transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
       <!-- <img class="br-8px mr-10px" src={preview.src} alt={'receipt'} /> -->
       <div>
-        <p class="white">{preview.file.name}</p>
-        <p class="white">{preview.created_at}</p>
+        <p class="white my-0">{preview.file.name}</p>
+        <p class="white my-0">{preview.created_at}</p>
       </div>
       <Button class="delete-button" raised on:click={evt => onDelete(evt, preview.id)}>Delete</Button>
     </div>

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -10,6 +10,8 @@ export let uploading = false
 
 const dispatch = createEventDispatcher()
 
+const onClick = id => dispatch('preview', id)
+
 function onDelete(event, id) {
   event.preventDefault()
 
@@ -25,7 +27,7 @@ function onDelete(event, id) {
 
 <div class="mt-10px py-10px">
   {#each previews as preview (preview.id)}
-    <div transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
+    <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
       <div>
         <p class="white my-0">{preview.file.name}</p>
         <p class="white my-0">{formatDate(preview.created_at)}</p>

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -1,0 +1,36 @@
+<script>
+import { Button, Progress } from '@silintl/ui-components'
+import { flip } from 'svelte/animate'
+import { fly } from 'svelte/transition'
+
+export let previews = []
+export let uploading = false
+
+function onDelete(event, id) {
+  event.preventDefault()
+
+  dispatch('deleted', id)
+}
+</script>
+
+<style>
+.preview {
+  background-color: hsla(213, 26%, 23%, 1);
+}
+</style>
+
+<div class="mt-10px py-10px">
+  {#each previews as preview (preview.id)}
+    <div transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
+      <!-- <img class="br-8px mr-10px" src={preview.src} alt={'receipt'} /> -->
+      <div>
+        <p class="white">{preview.file.name}</p>
+        <p class="white">{preview.created_at}</p>
+      </div>
+      <Button class="delete-button" raised on:click={evt => onDelete(evt, preview.id)}>Delete</Button>
+    </div>
+  {/each}
+  {#if uploading}
+    <Progress.Circular />
+  {/if}
+</div>

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -48,7 +48,7 @@ function onDelete(event, id) {
 }
 </style>
 
-<div class="mt-10px py-10px">
+<div class="mt-10px py-10px {$$props.class}">
   {#each previews as preview (preview.id)}
     <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class:selected={isSelected[preview.id]} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
       <div>

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -8,9 +8,28 @@ import { fly } from 'svelte/transition'
 export let previews = []
 export let uploading = false
 
+let selectedId = ''
+
 const dispatch = createEventDispatcher()
 
-const onClick = id => dispatch('preview', id)
+const isSelected = {}
+
+$: isSelected[selectedId] = true
+$: selectedId && setOthersFalse(selectedId)
+
+const setOthersFalse = id => {
+  for(const key of Object.keys(isSelected)){
+    if(key != id){
+      isSelected[key] = false
+    }
+  }
+}
+
+const onClick = id => {
+  selectedId = id
+
+  dispatch('preview', id)
+}
 
 function onDelete(event, id) {
   event.preventDefault()
@@ -24,11 +43,14 @@ function onDelete(event, id) {
 .preview {
   background-color: hsla(213, 26%, 23%, 1);
 }
+.selected {
+  background-color: hsla(213, 26%, 23%, .6);
+}
 </style>
 
 <div class="mt-10px py-10px">
   {#each previews as preview (preview.id)}
-    <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
+    <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class:selected={isSelected[preview.id]} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
       <div>
         <p class="white my-0">{preview.file.name}</p>
         <p class="white my-0">{formatDate(preview.created_at)}</p>

--- a/src/components/FilePreview/_index.scss
+++ b/src/components/FilePreview/_index.scss
@@ -1,0 +1,9 @@
+@use "@material/button";
+
+.delete-button {
+  --mdc-theme-primary: hsla(213, 26%, 23%, 1);
+  
+  @include button.ink-color(hsla(0, 0%, 100%, 1));
+
+  border: 2px solid white;
+}

--- a/src/components/FilePreview/index.js
+++ b/src/components/FilePreview/index.js
@@ -1,0 +1,4 @@
+import './_index.scss'
+import FilePreview from './FilePreview.svelte'
+
+export default FilePreview

--- a/src/components/dates.js
+++ b/src/components/dates.js
@@ -1,8 +1,8 @@
 export const formatDate = dateString => {
-    if (dateString) {
-      const date = new Date(dateString)
-      return date.toLocaleDateString("default", {month: 'long', day: 'numeric', year: 'numeric'})
-    }
-    return ''
+  if (dateString) {
+    const date = new Date(dateString)
+    return date.toLocaleDateString("default", {month: 'long', day: 'numeric', year: 'numeric'})
   }
+  return ''
+}
   

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,7 @@ import DateInput from './DateInput.svelte'
 import DependentForm from './forms/DependentForm.svelte'
 import Description from './Description.svelte'
 import FileDropArea from './FileDropArea'
+import FilePreview from './FilePreview'
 import ItemForm from './forms/ItemForm.svelte'
 import MoneyInput from './MoneyInput.svelte'
 import RadioOptions from './RadioOptions.svelte'
@@ -33,6 +34,7 @@ export {
   DependentForm,
   Description,
   FileDropArea,
+  FilePreview,
   ItemForm,
   MoneyInput,
   RadioOptions,

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -167,7 +167,7 @@ function onDeleted(event) {
         <br/>
 
         <div class="w-50">
-          <FileDropArea class="w-50" raised previews={claimFiles} {uploading} on:upload={onUpload} on:deleted={onDeleted}/>
+          <FileDropArea raised previews={claimFiles} {uploading} on:upload={onUpload} on:deleted={onDeleted}/>
 
           <FilePreview previews={claimFiles} on:deleted={onDeleted} />
         </div>

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -167,7 +167,7 @@ function onDeleted(event) {
         <br/>
 
         <div class="w-50">
-          <FileDropArea raised previews={claimFiles} {uploading} on:upload={onUpload} on:deleted={onDeleted}/>
+          <FileDropArea raised {uploading} on:upload={onUpload} />
 
           <FilePreview previews={claimFiles} on:deleted={onDeleted} />
         </div>

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -148,26 +148,20 @@ function onDeleted(event) {
     <p>
       <Button on:click={editClaim} outlined>Edit claim</Button>
     </p>
-    {#if needsReceipt || true}
-      <Form>
-        <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} on:blur={onBlur}/>
+    {#if needsReceipt}
+      <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} on:blur={onBlur}/>
 
-        <p class="label ml-1 mt-6px">
-          <ConvertCurrencyLink />
-        </p>
+      <p class="label ml-1 mt-6px">
+        <ConvertCurrencyLink />
+      </p>
 
-        <label for="receipt" class="ml-1">Attach replacement item receipt</label>
+      <label for="receipt" class="ml-1">Attach replacement item receipt</label>
 
-        <br/>
-
-        <div class="w-50">
-          <FileDropArea raised {uploading} on:upload={onUpload} />
-
-          <FilePreview previews={claimFiles} on:deleted={onDeleted} on:preview={onPreview} />
-        </div>
-
-        <br/>
-      </Form>
+      <FileDropArea class="w-50 mt-10px" raised {uploading} on:upload={onUpload} />
     {/if}
+      
+    <FilePreview class="w-50" previews={claimFiles} on:deleted={onDeleted} on:preview={onPreview} />
+
+    <br/>
   </Row>
 </Page>

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -1,14 +1,12 @@
 <script>
 import user from '../../authn/user.js'
-import { Banner, ClaimBanner, ConvertCurrencyLink, FileDropArea, MoneyInput, Row } from '../../components'
+import { Banner, ClaimBanner, ConvertCurrencyLink, FileDropArea, FilePreview, MoneyInput, Row } from '../../components'
 import { formatDate } from '../../components/dates.js'
 import { upload } from '../../data'
 import { loadClaims, claims, initialized, claimsFileAttach, updateClaimItem } from '../../data/claims'
 import { loadItems, itemsByPolicyId } from '../../data/items'
 import { goto } from '@roxi/routify'
-import { Button, Form, Page, Progress } from '@silintl/ui-components'
-import { flip } from 'svelte/animate'
-import { fly } from 'svelte/transition'
+import { Button, Form, Page } from '@silintl/ui-components'
 
 export let claimId
 
@@ -111,13 +109,6 @@ function onDeleted(event) {
 .receipt {
   max-width: 400px;
 }
-.preview {
-  background-color: hsla(213, 26%, 23%, 1);
-}
-.preview img {
-  max-width: 50px;
-  vertical-align: middle;
-}
 </style>
 
 <Page layout="grid">
@@ -175,26 +166,11 @@ function onDeleted(event) {
 
         <br/>
 
-        <div>
+        <div class="w-50">
           <FileDropArea class="w-50" raised previews={claimFiles} {uploading} on:upload={onUpload} on:deleted={onDeleted}/>
 
-          <div class="mt-10px py-10px">
-            {#each claimFiles as preview (preview.id)}
-              <div transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
-                <!-- <img class="br-8px mr-10px" src={preview.src} alt={'receipt'} /> -->
-                <div>
-                  <p class="white">{preview.file.name}</p>
-                  <p class="white">{preview.created_at}</p>
-                </div>
-                <Button class="delete-button" raised on:click={evt => onDelete(evt, preview.id)}>Delete</Button>
-              </div>
-            {/each}
-            {#if uploading}
-              <Progress.Circular />
-            {/if}
-          </div>
+          <FilePreview previews={claimFiles} on:deleted={onDeleted} />
         </div>
-
 
         <br/>
       </Form>


### PR DESCRIPTION
Talked with Alex and found out the previews are actully uploaded.

## Removed
- upload receipt button
- each loop showing receipts
- onSubmit
- thumbnail from previews

## Changed
- Upload now uploads and attaches files to claims
- moved previews into FilePreview component
- show one receipt at a time

# Added
- FilePreview component
- preview event to show one image
-  show created_at

![Screen Shot 2021-09-08 at 7 12 02 PM](https://user-images.githubusercontent.com/70765247/132597890-a7d9d0f6-95cc-417d-8b99-470d50570810.png)