### PR TITLE
ClaimCard action revision

### DIFF
--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -16,13 +16,7 @@ $: msAgo = now - Date.parse(claimItem.updated_at)
 $: daysAgo = msAgo > 0 ? Math.floor(msAgo/day) : '-'
 $: state = getState(claim.status) || {}
 
-const editClaim = () => dispatch('edit-claim', claim.id)
 const gotoClaim = () => dispatch('goto-claim', claim.id)
-const onKeyPress = event => {
-  if (event.code === 'Space' || event.code === 'Enter') {
-    gotoClaim()
-  }
-}
 </script>
 
 <style>
@@ -49,7 +43,7 @@ const onKeyPress = event => {
 }
 </style>
 
-<Card isClickable noPadding on:click={gotoClaim} on:keypress={onKeyPress} class="height-fit-content py-0 {$$props.class}">
+<Card noPadding class="height-fit-content py-0 {$$props.class}">
   <ClaimCardBanner {item} {state} />
 
   <div class="mdc-typography--headline5 multi-line-truncate content ml-50px">
@@ -61,7 +55,7 @@ const onKeyPress = event => {
   </div>
 
   <div class="action pb-2 ml-50px" slot="actions">
-    <Button raised on:click={editClaim}>{state.actionLabel || 'Edit Claim'}</Button>
+    <Button raised on:click={gotoClaim}>{'View claim'}</Button>
 
     <div class="fs-12 gray mt-1">
       {#if daysAgo}

--- a/src/components/ClaimCards.svelte
+++ b/src/components/ClaimCards.svelte
@@ -17,7 +17,7 @@ export let items
     {#each (claim.claim_items || []) as claimItem (claimItem.id) }
       <div class="card">
         <ClaimCard {claim} {claimItem} item={items.find(item => item.id === claimItem.item_id)}
-                   on:edit-claim on:goto-claim />
+                  on:goto-claim />
       </div>
     {/each}
   {/each}

--- a/src/components/ClaimCards.svelte
+++ b/src/components/ClaimCards.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 import { ClaimCard } from './index'
+import { goto } from '@roxi/routify'
 
 export let claims
 export let items
+
+const onGotoClaim = event => $goto(`/claims/${event.detail}`)
 </script>
 
 <style>
@@ -17,7 +20,7 @@ export let items
     {#each (claim.claim_items || []) as claimItem (claimItem.id) }
       <div class="card">
         <ClaimCard {claim} {claimItem} item={items.find(item => item.id === claimItem.item_id)}
-                  on:goto-claim />
+                  on:goto-claim={onGotoClaim} />
       </div>
     {/each}
   {/each}

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -10,14 +10,12 @@ export const warning = {
   color: '--mdc-theme-status-warning',
   bgColor: '--mdc-theme-status-warning-bg',
   title: 'Needs changes',
-  actionLabel: 'Make changes',
 }
 export const success = {
   icon: 'done',
   color: '--mdc-theme-status-success',
   bgColor: '--mdc-theme-status-success-bg',
   title: 'Approved for repair',
-  actionLabel: 'View and upload receipt',
 }
 export const states = {
   Message: {
@@ -25,21 +23,18 @@ export const states = {
     color: '--mdc-theme-primary',
     bgColor: '--mdc-theme-primary-header-bg',
     title: 'From ',
-    actionLabel: 'View message',
   },
   Draft: {
     icon: 'edit',
     color: '--mdc-theme-primary',
     bgColor: '--mdc-theme-primary-header-bg',
     title: 'Draft',
-    actionLabel: 'Edit claim',
   },
   Pending: {
     icon: 'watch_later',
     color: '--mdc-theme-neutral-variant',
     bgColor: '--mdc-theme-neutral-bg',
     title: 'Awaiting review',
-    actionLabel: 'View claim',
   },
   Needs_repair_receipt: success,
   Needs_repair_receipt2: warning,
@@ -50,7 +45,6 @@ export const states = {
     color: '--mdc-theme-status-error',
     bgColor: '--mdc-theme-status-error-bg',
     title: 'Denied',
-    actionLabel: 'View denial',
   },
   Approved: success,
   Payout: {
@@ -58,14 +52,12 @@ export const states = {
     color: '--mdc-theme-status-success',
     bgColor: '--mdc-theme-status-success-bg',
     title: 'Approved for payout',
-    actionLabel: 'View claim',
   },
   Complete: {
     icon: 'paid',
     color: '--mdc-theme-status-success',
     bgColor: '--mdc-theme-status-success-bg',
     title: 'Complete',
-    actionLabel: 'View claim',
   }
 }
 

--- a/src/pages/claims.svelte
+++ b/src/pages/claims.svelte
@@ -3,7 +3,6 @@ import user from '../authn/user'
 import { ClaimCards, Row } from '../components/'
 import { claims, initialized as claimsInitialized, loadClaims } from '../data/claims'
 import { itemsByPolicyId, loadItems } from '../data/items'
-import { goto } from '@roxi/routify'
 import { Page, Button } from '@silintl/ui-components'
 
 $: $claimsInitialized || loadClaims()
@@ -11,8 +10,6 @@ $: $claimsInitialized || loadClaims()
 $: policyId = $user.policy_id
 $: policyId && loadItems(policyId)
 $: items = $itemsByPolicyId[policyId] || []
-
-const onGotoClaim = event => $goto(`/claims/${event.detail}`)
 </script>
 
 <Page layout="grid">
@@ -22,7 +19,7 @@ const onGotoClaim = event => $goto(`/claims/${event.detail}`)
 
   <Row cols={'12'}>
     {#if $claims.length}
-      <ClaimCards claims={$claims} {items} on:goto-claim={onGotoClaim} />
+      <ClaimCards claims={$claims} {items} />
     {:else}
       No claims at this time.
     {/if}

--- a/src/pages/claims.svelte
+++ b/src/pages/claims.svelte
@@ -12,14 +12,7 @@ $: policyId = $user.policy_id
 $: policyId && loadItems(policyId)
 $: items = $itemsByPolicyId[policyId] || []
 
-const onEditClaim = event => {
-  const claimId = event.detail
-  $goto(`/claims/${claimId}/edit`)
-}
-const onGotoClaim = event => {
-  const claimId = event.detail
-  $goto(`/claims/${claimId}`)
-}
+const onGotoClaim = event => $goto(`/claims/${event.detail}`)
 </script>
 
 <Page layout="grid">
@@ -29,7 +22,7 @@ const onGotoClaim = event => {
 
   <Row cols={'12'}>
     {#if $claims.length}
-      <ClaimCards claims={$claims} {items} on:edit-claim={onEditClaim} on:goto-claim={onGotoClaim} />
+      <ClaimCards claims={$claims} {items} on:goto-claim={onGotoClaim} />
     {:else}
       No claims at this time.
     {/if}

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -7,7 +7,7 @@ import { loadClaims, claims, initialized, claimsFileAttach, updateClaimItem } fr
 import { loadItems, itemsByPolicyId } from '../../data/items'
 import { formatMoney } from '../../helpers/money'
 import { goto } from '@roxi/routify'
-import { Button, Form, Page } from '@silintl/ui-components'
+import { Button, Page } from '@silintl/ui-components'
 
 export let claimId
 


### PR DESCRIPTION
Alex told me ClaimCard action should be 'View claim' and the entire card non-clickable.

### removed
- editClaim, onKeyPress from ClaimCard
- actionLabel from states

### changed
- moved gotoClaim to claimCards.svelte since the action button wasn't working in /home
