### PR TITLE
Draft uploads and file purpose

### DIFF
--- a/src/business-rules/claim-payout-amount.js
+++ b/src/business-rules/claim-payout-amount.js
@@ -4,7 +4,7 @@ export const LOSS_REASON_EVACUATION = 'Evacuation'
 export const PAYOUT_OPTION_FIXED_FRACTION = 'FixedFraction'
 export const PAYOUT_OPTION_FMV = 'FMV'
 export const PAYOUT_OPTION_REPAIR = 'Repair'
-export const PAYOUT_OPTION_REPLACE = 'Replace'
+export const PAYOUT_OPTION_REPLACE = 'Replacement'
 
 export const isFairMarketValueNeeded = (isRepairable, payoutOption) => {
   return isRepairable || (payoutOption === PAYOUT_OPTION_FMV)

--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -1,10 +1,11 @@
+import type { PayoutOption } from '../data/claims'
 
 export const LOSS_REASON_EVACUATION = 'Evacuation'
 
-export const PAYOUT_OPTION_FIXED_FRACTION = 'FixedFraction'
-export const PAYOUT_OPTION_FMV = 'FMV'
-export const PAYOUT_OPTION_REPAIR = 'Repair'
-export const PAYOUT_OPTION_REPLACE = 'Replacement'
+export const PAYOUT_OPTION_FIXED_FRACTION: PayoutOption = 'FixedFraction'
+export const PAYOUT_OPTION_FMV: PayoutOption = 'FMV'
+export const PAYOUT_OPTION_REPAIR: PayoutOption = 'Repair'
+export const PAYOUT_OPTION_REPLACE: PayoutOption = 'Replacement'
 
 export const isFairMarketValueNeeded = (isRepairable, payoutOption) => {
   return isRepairable || (payoutOption === PAYOUT_OPTION_FMV)

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -50,7 +50,8 @@ function onDelete(event, id) {
 
 <div class="mt-10px py-10px {$$props.class}">
   {#each previews as preview (preview.id)}
-    <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 1500 }} animate:flip={{duration: 500}} class:selected={isSelected[preview.id]} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
+    <!-- TODO: fix - transition has to finish before leaving page -->
+    <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 500 }} animate:flip={{duration: 500}} class:selected={isSelected[preview.id]} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
       <div>
         <p class="white my-0">{preview.file.name}</p>
         <p class="white my-0">{formatDate(preview.created_at)}</p>

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -3,7 +3,6 @@ import { formatDate } from '../dates'
 import { Button, Progress } from '@silintl/ui-components'
 import { createEventDispatcher } from "svelte"
 import { flip } from 'svelte/animate'
-import { fly } from 'svelte/transition'
 
 export let previews = []
 export let uploading = false
@@ -48,10 +47,9 @@ function onDelete(event, id) {
 }
 </style>
 
-<!-- TODO: fix - transition has to finish before leaving page -->
 <div class="mt-10px py-10px {$$props.class}">
   {#each previews as preview (preview.id)}
-    <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 500 }} animate:flip={{duration: 500}} class:selected={isSelected[preview.id]} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
+    <div on:click|preventDefault={() => onClick(preview.id)} animate:flip={{duration: 500}} class:selected={isSelected[preview.id]} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
       <div>
         <p class="white my-0">{preview.file.name}</p>
         <p class="white my-0">{formatDate(preview.created_at)}</p>

--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -48,9 +48,9 @@ function onDelete(event, id) {
 }
 </style>
 
+<!-- TODO: fix - transition has to finish before leaving page -->
 <div class="mt-10px py-10px {$$props.class}">
   {#each previews as preview (preview.id)}
-    <!-- TODO: fix - transition has to finish before leaving page -->
     <div on:click|preventDefault={() => onClick(preview.id)} transition:fly={{ y: 200, duration: 500 }} animate:flip={{duration: 500}} class:selected={isSelected[preview.id]} class="preview flex justify-between align-items-center br-8px p-10px mb-1">
       <div>
         <p class="white my-0">{preview.file.name}</p>

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -263,12 +263,12 @@ export async function updateClaim(claimId: string, newClaimData) {
   return updatedClaim
 }
 
-export async function claimsFileAttach(claimId: string, fileId: string) {
+export async function claimsFileAttach(claimId: string, fileId: string, purpose: ClaimFilePurpose) {
   start(fileId)
 
   const data: ClaimsFileAttachRequestBody = {
     file_id: fileId,
-    purpose: undefined // TODO: get this value
+    purpose,
   };
   await CREATE<ClaimsFileAttachResponseBody>(`claims/${claimId}/files`, data)
 

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -144,6 +144,7 @@ export const states: { [stateName: string]: State} = {
     bgColor: '--mdc-theme-primary-header-bg',
     title: 'Draft',
   },
+  Draft2: warning,
   Pending: pending,
   Review1: pending,
   Needs_repair_receipt: success,

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -55,7 +55,7 @@ const computeReplaceMaxPayout = () => computePayout(claimItem.replace_estimate, 
 
 const computeCashMaxPayout = () => computePayout(item.coverage_amount, claimItem.fmv)
 
-const getFilePurpose = (claimItem, needsReceipt): ClaimFilePurpose => {
+const getFilePurpose = (claimItem: ClaimItem, needsReceipt: Boolean): ClaimFilePurpose => {
   if(needsReceipt) return 'Receipt'
   if(claimItem.repair_estimate) return 'Repair Estimate'
   if(claimItem.fmv) return 'Evidence of FMV'

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -19,6 +19,7 @@ let uploading = false
 let deductible = .05
 let maximumPayout: number | '' = ''
 let previewFile = {} as ClaimFile
+let uploadLabel: string = ''
 
 $: $initialized || loadClaims()
 
@@ -58,9 +59,18 @@ const computeReplaceMaxPayout = () => computePayout(claimItem.replace_estimate, 
 const computeCashMaxPayout = () => computePayout(item.coverage_amount, claimItem.fmv)
 
 const getFilePurpose = (claimItem: ClaimItem, needsReceipt: Boolean): ClaimFilePurpose => {
-  if(needsReceipt) return 'Receipt'
-  if(claimItem.repair_estimate) return 'Repair Estimate'
-  if(claimItem.fmv) return 'Evidence of FMV'
+  if(needsReceipt){
+    uploadLabel = 'Attach replacement item receipt'
+    return 'Receipt'
+  }
+  if(claimItem.repair_estimate){
+    uploadLabel = 'Attach repair estimate'
+    return 'Repair Estimate'
+  }
+  if(claimItem.fmv){
+    uploadLabel = 'Attach evidence of fair market value'
+    return 'Evidence of FMV'
+  }
 }
 
 const editClaim = () => $goto(`claims/${claimId}/edit)`)
@@ -164,15 +174,18 @@ function onDeleted(event) {
         <Button raised on:click={onSubmit}>Submit claim</Button>
       {/if}
     </p>
-    {#if needsFile}
-      <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} on:blur={onBlur}/>
 
+    {#if needsReceipt}
+      <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} on:blur={onBlur}/>
+      
       <p class="label ml-1 mt-6px">
         <ConvertCurrencyLink />
       </p>
+    {/if}
 
-      <label for="receipt" class="ml-1">Attach replacement item receipt</label>
-
+    {#if needsFile}
+      <label for="receipt" class="ml-1">{uploadLabel}</label>
+    
       <FileDropArea class="w-50 mt-10px" raised {uploading} on:upload={onUpload} />
     {/if}
       

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -17,7 +17,7 @@ let showImg = false
 let repairOrReplacementCost: number
 let uploading = false
 let deductible = .05
-let maximumPayout: number | '' = ''
+let maximumPayout: string
 let previewFile = {} as ClaimFile
 
 $: $initialized || loadClaims()
@@ -47,10 +47,10 @@ $: if(payoutOption === 'Repair') {
   } else if(payoutOption === 'FMV') {
     maximumPayout = computeCashMaxPayout()
   } else if(claim.event_type === 'Evacuation') {
-    maximumPayout = item.coverage_amount * 2/3 || ''
+    maximumPayout = formatMoney(item.coverage_amount * 2/3) || ''
   }
 
-const computePayout = (...values) => Math.min(...values) * (1 - deductible) || ''
+const computePayout = (...values) => formatMoney(Math.min(...values) * (1 - deductible)) || ''
 
 const computeRepairMaxPayout = () => computePayout(claimItem.repair_estimate || claimItem.repair_actual, item.coverage_amount, claimItem.fmv)
 

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -19,7 +19,6 @@ let uploading = false
 let deductible = .05
 let maximumPayout: number | '' = ''
 let previewFile = {} as ClaimFile
-let uploadLabel: string = ''
 
 $: $initialized || loadClaims()
 
@@ -37,6 +36,7 @@ $: needsReceipt = (needsRepairReceipt || needsReplaceReceipt)
 $: needsEvidence = ((claimItem.fmv || claimItem.repair_estimate) && status === 'Draft') as Boolean
 $: needsFile = (needsReceipt || needsEvidence) as Boolean
 $: filePurpose = getFilePurpose(claimItem, needsReceipt)
+$: uploadLabel = getUploadLabel(claimItem, needsReceipt) as string
 $: moneyFormLabel = needsRepairReceipt ? "Actual cost of repair" : "Actual cost of replacement"
 $: receiptType = needsRepairReceipt ? 'repair' : 'replacement'
 $: claimFiles = claim.claim_files || []
@@ -59,18 +59,15 @@ const computeReplaceMaxPayout = () => computePayout(claimItem.replace_estimate, 
 const computeCashMaxPayout = () => computePayout(item.coverage_amount, claimItem.fmv)
 
 const getFilePurpose = (claimItem: ClaimItem, needsReceipt: Boolean): ClaimFilePurpose => {
-  if(needsReceipt){
-    uploadLabel = 'Attach replacement item receipt'
-    return 'Receipt'
-  }
-  if(claimItem.repair_estimate){
-    uploadLabel = 'Attach repair estimate'
-    return 'Repair Estimate'
-  }
-  if(claimItem.fmv){
-    uploadLabel = 'Attach evidence of fair market value'
-    return 'Evidence of FMV'
-  }
+  if(needsReceipt) return 'Receipt'
+  if(claimItem.repair_estimate) return 'Repair Estimate'
+  if(claimItem.fmv) return 'Evidence of FMV'
+}
+
+const getUploadLabel = (claimItem: ClaimItem, needsReceipt: Boolean) => {
+  if(needsReceipt) return 'Attach replacement item receipt'
+  if(claimItem.repair_estimate) return 'Attach repair estimate'
+  if(claimItem.fmv) return 'Attach evidence of fair market value'
 }
 
 const editClaim = () => $goto(`claims/${claimId}/edit)`)

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -65,9 +65,9 @@ const getFilePurpose = (claimItem: ClaimItem, needsReceipt: Boolean): ClaimFileP
 }
 
 const getUploadLabel = (claimItem: ClaimItem, needsReceipt: Boolean) => {
-  if(needsReceipt) return 'Attach replacement item receipt'
-  if(claimItem.repair_estimate) return 'Attach repair estimate'
-  if(claimItem.fmv) return 'Attach evidence of fair market value'
+  if(needsReceipt) return `a ${receiptType} item receipt`
+  if(claimItem.repair_estimate) return 'a repair estimate'
+  if(claimItem.fmv) return 'evidence of fair market value'
 }
 
 const editClaim = () => $goto(`claims/${claimId}/edit)`)
@@ -143,9 +143,9 @@ function onDeleted(event) {
   </Row>
   <Row cols="9">
     <ClaimBanner claimStatus={status} />
-    {#if needsReceipt}
+    {#if needsFile}
       <ClaimBanner claimStatus={`${status}2`} >
-        Upload a {receiptType} receipt to get reimbursed.
+        Upload {uploadLabel} to get reimbursed.
       </ClaimBanner>
     {/if}
     <p>
@@ -181,7 +181,7 @@ function onDeleted(event) {
     {/if}
 
     {#if needsFile}
-      <label for="receipt" class="ml-1">{uploadLabel}</label>
+      <label for="receipt" class="ml-1">Attach {uploadLabel}</label>
     
       <FileDropArea class="w-50 mt-10px" raised {uploading} on:upload={onUpload} />
     {/if}

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -33,6 +33,8 @@ $: payoutOption = claimItem.payout_option
 $: needsRepairReceipt = (status === 'Needs_repair_receipt')
 $: needsReplaceReceipt = (status === 'Needs_replace_receipt')
 $: needsReceipt = (needsRepairReceipt || needsReplaceReceipt)
+$: needsEvidence = ((claimItem.fmv || claimItem.repair_estimate) && status === 'Draft') as Boolean
+$: needsFile = (needsReceipt || needsEvidence) as Boolean
 $: filePurpose = getFilePurpose(claimItem, needsReceipt)
 $: moneyFormLabel = needsRepairReceipt ? "Actual cost of repair" : "Actual cost of replacement"
 $: receiptType = needsRepairReceipt ? 'repair' : 'replacement'
@@ -162,7 +164,7 @@ function onDeleted(event) {
         <Button raised on:click={onSubmit}>Submit claim</Button>
       {/if}
     </p>
-    {#if needsReceipt}
+    {#if needsFile}
       <MoneyInput bind:value={repairOrReplacementCost} label={moneyFormLabel} on:blur={onBlur}/>
 
       <p class="label ml-1 mt-6px">


### PR DESCRIPTION
### Added
- filePurpose
- getFilePurpose()
- needsEvidence
- needsFile
- uploadLabel

### Changed
- control block around FileDropArea and MoneyInput in [claimID]
- animation delay on FilePreview
- business-rules to use ts

### Fixed
- bug: wrong payout option 'replace'

Realized we need the second "needs changes" banner since we are requiring files.
![Screenshot from 2021-09-15 15-53-33](https://user-images.githubusercontent.com/70765247/133500910-d98242cd-edd1-452a-bf18-03b595391796.png)
