### PR TITLE
Add a policies page

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -2,10 +2,8 @@ import { CREATE, DELETE, GET, UPDATE } from "."
 import { start, stop } from "../components/progress"
 import { throwError } from "../error"
 import { writable } from "svelte/store"
-import type { Claim } from "./claims"
 
 export type ItemCoverageStatus = 'Draft' | 'Pending' | 'Approved' | 'Denied';
-export type PolicyType = 'Household' | 'Corporate';
 
 export type RiskCategory = {
   created_at: string /*Date*/;
@@ -34,20 +32,6 @@ export type PolicyItem = {
   purchase_date: string /* yyyy-mm-dd Date */;
   risk_category: RiskCategory;
   serial_number: string;
-  updated_at: string /*Date*/;
-}
-
-export type Policy = {
-  account: string;
-  claims: Claim[];
-  cost_center: string;
-  created_at: string /*Date*/;
-  dependents: any[] /*PolicyDependents*/;
-  entity_code: any /*EntityCode*/;
-  household_id: string;
-  id: string;
-  members: any[] /*PolicyMembers*/;
-  type: PolicyType;
   updated_at: string /*Date*/;
 }
 

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -14,9 +14,11 @@ export type Policy = {
   household_id: string;
   id: string;
   members: PolicyMember[];
-  type: string;
+  type: PolicyType;
   updated_at: string /*Date*/;
 }
+
+export type PolicyType = 'Household' | 'Corporate';
 
 export type UpdatePolicyRequestBody = {
   account: string;

--- a/src/pages/policies.svelte
+++ b/src/pages/policies.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { initialized, loadPolicies, policies } from '../data/policies'
+import { goto } from '@roxi/routify'
+import { Datatable, Page } from '@silintl/ui-components'
+
+$: $initialized || loadPolicies()
+</script>
+
+<Page>
+  <Datatable>
+    <Datatable.Header>
+      <Datatable.Header.Item>Type</Datatable.Header.Item>
+      <Datatable.Header.Item>Household ID</Datatable.Header.Item>
+      <Datatable.Header.Item>Account</Datatable.Header.Item>
+      <Datatable.Header.Item>Cost Center</Datatable.Header.Item>
+      <Datatable.Header.Item>Entity Code</Datatable.Header.Item>
+      <Datatable.Header.Item>Members</Datatable.Header.Item>
+      <Datatable.Header.Item>Claims</Datatable.Header.Item>
+    </Datatable.Header>
+    <Datatable.Data>
+      {#each $policies as policy (policy.id) }
+        <Datatable.Data.Row on:click={() => $goto(`/policies/${policy.id}`)} clickable>
+          <Datatable.Data.Row.Item>{policy.type || ''}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{policy.household_id || ''}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{policy.account || ''}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{policy.cost_center || ''}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{policy.entity_code?.code || ''}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{policy.members?.length || 0}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{policy.claims?.length || 0}</Datatable.Data.Row.Item>
+        </Datatable.Data.Row>
+        {/each}
+    </Datatable.Data>
+  </Datatable>
+</Page>


### PR DESCRIPTION
### Added
- Add simple Policies page/table (mostly for administrative purposes)

### Fixed
- Remove duplicate `Policy` definition from items data file
- Move `PolicyType` from items to claims data file