### PR TITLE
Rename event to incident

### DIFF
--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -18,8 +18,8 @@ export const isPotentiallyRepairable = (claimIncidentTypes, incidentTypeName) =>
   if (claimIncidentTypes.length < 1) {
     return true
   }
-  const repairableEventTypes = claimIncidentTypes.filter(type => type.is_repairable)
-  return repairableEventTypes.some(type => type.name === incidentTypeName)
+  const repairableIncidentTypes = claimIncidentTypes.filter(type => type.is_repairable)
+  return repairableIncidentTypes.some(type => type.name === incidentTypeName)
 }
 
 export const isRepairCostTooHigh = (repairEstimateUSD, fairMarketValueUSD) => {

--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -11,15 +11,15 @@ export const isFairMarketValueNeeded = (isRepairable, payoutOption) => {
   return isRepairable || (payoutOption === PAYOUT_OPTION_FMV)
 }
 
-export const isPotentiallyRepairable = (claimEventTypes, eventTypeName) => {
-  if (!eventTypeName) {
+export const isPotentiallyRepairable = (claimIncidentTypes, incidentTypeName) => {
+  if (!incidentTypeName) {
     return true
   }
-  if (claimEventTypes.length < 1) {
+  if (claimIncidentTypes.length < 1) {
     return true
   }
-  const repairableEventTypes = claimEventTypes.filter(type => type.is_repairable)
-  return repairableEventTypes.some(type => type.name === eventTypeName)
+  const repairableEventTypes = claimIncidentTypes.filter(type => type.is_repairable)
+  return repairableEventTypes.some(type => type.name === incidentTypeName)
 }
 
 export const isRepairCostTooHigh = (repairEstimateUSD, fairMarketValueUSD) => {

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -69,7 +69,6 @@ let claimItems: ClaimItem[] = []
 let isEvacuation = undefined
 let lossReasonOptions = []
 let potentiallyRepairable = true
-let repairableEventTypeNames = []
 let repairableSelection = undefined
 let repairCostIsTooHigh = undefined
 let shouldAskIfRepairable = false

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -144,11 +144,11 @@ const onSubmit = async () => {
   })
 }
 const setInitialValues = (claim, claimItem) => {
-  if (claim.event_date) {
-    lostDate = claim.event_date.split('T')[0]
+  if (claim.incident_date) {
+    lostDate = claim.incident_date.split('T')[0]
   }
-  lossReason = claim.event_type || lossReason
-  situationDescription = claim.event_description || situationDescription
+  lossReason = claim.incident_type || lossReason
+  situationDescription = claim.incident_description || situationDescription
   if (claimItem.is_repairable !== undefined) {
     repairableSelection = (claimItem.is_repairable ? 'repairable' : 'not_repairable')
   }

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -17,7 +17,7 @@ import {
   DateInput,
   MoneyInput,
 } from '../../components'
-import { claimEventTypes, loadClaimEventTypes } from '../../data/claim-event-types'
+import { claimIncidentTypes, loadClaimIncidentTypes } from '../../data/claim-incident-types'
 import type { Claim, ClaimItem } from '../../data/claims'
 import type { PolicyItem } from '../../data/items'
 import { Button, Form, TextArea } from '@silintl/ui-components'
@@ -81,7 +81,7 @@ let unrepairableOrTooExpensive = undefined
 $: setInitialValues(claim, claimItem)
 
 // Load the necessary data.
-$: $claimEventTypes.length || loadClaimEventTypes()
+$: $claimIncidentTypes.length || loadClaimIncidentTypes()
 
 // Find applicable data from component props.
 $: claimItems = claim.claim_items || []
@@ -89,7 +89,7 @@ $: claimItem = claimItems.find(entry => entry.item_id === item.id) || {} as Clai
 
 // Define rules for reactive variables.
 $: isEvacuation = (lossReason === LOSS_REASON_EVACUATION)
-$: potentiallyRepairable = isPotentiallyRepairable($claimEventTypes, lossReason)
+$: potentiallyRepairable = isPotentiallyRepairable($claimIncidentTypes, lossReason)
 $: isRepairable = calculateIsRepairable(potentiallyRepairable, repairableSelection)
 $: repairCostIsTooHigh = isRepairCostTooHigh(repairEstimateUSD, fairMarketValueUSD)
 $: unrepairableOrTooExpensive = isUnrepairableOrTooExpensive(isRepairable, repairCostIsTooHigh)
@@ -103,7 +103,7 @@ $: !shouldAskForFMV && unSetFairMarketValue()
 $: !isRepairable && unSetRepairEstimate()
 
 // Calculate dynamic options for radio-button prompts.
-$: lossReasonOptions = $claimEventTypes.map(({name}) => ({ label: name, value: name }))
+$: lossReasonOptions = $claimIncidentTypes.map(({name}) => ({ label: name, value: name }))
 
 // TODO: get accountable person from item
 // TODO: add reimbursed value

--- a/src/data/claim-event-types.ts
+++ b/src/data/claim-event-types.ts
@@ -2,20 +2,20 @@ import { GET } from '.'
 import { start, stop } from '../components/progress'
 import { writable } from 'svelte/store'
 
-export type ClaimEventType = {
+export type ClaimIncidentType = {
   name: string;
   is_repairable: boolean;
 }
 
-export const claimEventTypes = writable<ClaimEventType[]>([])
+export const claimIncidentTypes = writable<ClaimIncidentType[]>([])
 
-export async function loadClaimEventTypes() {
+export async function loadClaimIncidentTypes() {
   const urlPath = 'config/claim-event-types'
   start(urlPath)
 
-  const results = await GET<ClaimEventType[]>(urlPath)
+  const results = await GET<ClaimIncidentType[]>(urlPath)
 
   stop(urlPath)
   
-  claimEventTypes.set(results)
+  claimIncidentTypes.set(results)
 }

--- a/src/data/claim-incident-types.ts
+++ b/src/data/claim-incident-types.ts
@@ -10,7 +10,7 @@ export type ClaimIncidentType = {
 export const claimIncidentTypes = writable<ClaimIncidentType[]>([])
 
 export async function loadClaimIncidentTypes() {
-  const urlPath = 'config/claim-event-types'
+  const urlPath = 'config/claim-incident-types'
   start(urlPath)
 
   const results = await GET<ClaimIncidentType[]>(urlPath)

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -50,9 +50,9 @@ export type ClaimItem = {
 export type Claim = {
   claim_files: ClaimFile[];
   claim_items: ClaimItem[];
-  event_date: string /*Date*/;
-  event_description: string;
-  event_type: ClaimIncidentTypeName;
+  incident_date: string /*Date*/;
+  incident_description: string;
+  incident_type: ClaimIncidentTypeName;
   id: string;
   payment_date: string /*Date*/;
   policy_id: string;
@@ -64,9 +64,9 @@ export type Claim = {
 }
 
 export type CreateClaimRequestBody = {
-  event_date: Date;
-  event_description: string;
-  event_type: ClaimIncidentTypeName;
+  incident_date: Date;
+  incident_description: string;
+  incident_type: ClaimIncidentTypeName;
 }
 
 export type CreateClaimItemRequestBody = {
@@ -79,9 +79,9 @@ export type CreateClaimItemRequestBody = {
 }
 
 export type UpdateClaimRequestBody = {
-  event_date: string /*Date*/;
-  event_description: string;
-  event_type: ClaimIncidentTypeName;
+  incident_date: string /*Date*/;
+  incident_description: string;
+  incident_type: ClaimIncidentTypeName;
 }
 
 export type ClaimsFileAttachRequestBody = {
@@ -192,9 +192,9 @@ export async function createClaim(item: PolicyItem, claimData) {
   start(urlPath)
 
   const parsedClaim: CreateClaimRequestBody = {
-    event_date: new Date(claimData.lostDate),
-    event_description: claimData.situationDescription,
-    event_type: claimData.lossReason,
+    incident_date: new Date(claimData.lostDate),
+    incident_description: claimData.situationDescription,
+    incident_type: claimData.lossReason,
   }
 
   const claim = await CREATE<Claim>(urlPath, parsedClaim)
@@ -248,9 +248,9 @@ export async function updateClaim(claimId: string, newClaimData) {
 
   //TODO make sure these properties are what is used in update claim form when it exists
   const parsedData: UpdateClaimRequestBody = {
-    event_date: newClaimData.event_date,
-    event_type: newClaimData.event_type, //TODO will get types from future GET /config endpoint
-    event_description: newClaimData.event_description,
+    incident_date: newClaimData.incident_date,
+    incident_type: newClaimData.incident_type, //TODO will get types from future GET /config endpoint
+    incident_description: newClaimData.incident_description,
   }
 
   const updatedClaim = await UPDATE<Claim>(`claims/${claimId}`, parsedData)

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -249,7 +249,7 @@ export async function updateClaim(claimId: string, newClaimData) {
   //TODO make sure these properties are what is used in update claim form when it exists
   const parsedData: UpdateClaimRequestBody = {
     incident_date: newClaimData.incident_date,
-    incident_type: newClaimData.incident_type, //TODO will get types from future GET /config endpoint
+    incident_type: newClaimData.incident_type,
     incident_description: newClaimData.incident_description,
   }
 

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -6,7 +6,7 @@ import { writable } from "svelte/store"
 
 export type PayoutOption = 'Repair' | 'Replacement' | 'FMV' | 'FixedFraction';
 export type ClaimItemStatus = 'Pending' | 'Approved' | 'Denied';
-export type ClaimIncidentTypeName = string; // dynamically defined by the claim-event-types endpoint
+export type ClaimIncidentTypeName = string; // dynamically defined by the claim-incident-types endpoint
 export type ClaimStatus = 'Draft' | 'Pending' | 'Approved' | 'Denied';
 export type ClaimFilePurpose = 'Receipt' | 'Evidence of FMV' | 'Repair Estimate'
 

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -6,7 +6,7 @@ import { writable } from "svelte/store"
 
 export type PayoutOption = 'Repair' | 'Replacement' | 'FMV' | 'FixedFraction';
 export type ClaimItemStatus = 'Pending' | 'Approved' | 'Denied';
-export type ClaimEventType = string; // dynamically defined by the claim-event-types endpoint
+export type ClaimIncidentTypeName = string; // dynamically defined by the claim-event-types endpoint
 export type ClaimStatus = 'Draft' | 'Pending' | 'Approved' | 'Denied';
 export type ClaimFilePurpose = 'Receipt' | 'Evidence of FMV' | 'Repair Estimate'
 
@@ -52,7 +52,7 @@ export type Claim = {
   claim_items: ClaimItem[];
   event_date: string /*Date*/;
   event_description: string;
-  event_type: ClaimEventType;
+  event_type: ClaimIncidentTypeName;
   id: string;
   payment_date: string /*Date*/;
   policy_id: string;
@@ -66,7 +66,7 @@ export type Claim = {
 export type CreateClaimRequestBody = {
   event_date: Date;
   event_description: string;
-  event_type: ClaimEventType;
+  event_type: ClaimIncidentTypeName;
 }
 
 export type CreateClaimItemRequestBody = {
@@ -81,7 +81,7 @@ export type CreateClaimItemRequestBody = {
 export type UpdateClaimRequestBody = {
   event_date: string /*Date*/;
   event_description: string;
-  event_type: ClaimEventType;
+  event_type: ClaimIncidentTypeName;
 }
 
 export type ClaimsFileAttachRequestBody = {

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -27,7 +27,7 @@ $: claimItem = claim.claim_items?.[0] || {} as ClaimItem //For now there will on
 $: items = $itemsByPolicyId[$user.policy_id] || []
 $: $user.policy_id && loadItems($user.policy_id)
 $: item = items.find(itm => itm.id === claimItem.item_id) || {} as PolicyItem
-$: eventDate = formatDate(claim.event_date)
+$: eventDate = formatDate(claim.incident_date)
 $: status = claim.status || ''
 $: payoutOption = claimItem.payout_option
 $: needsRepairReceipt = (status === 'Needs_repair_receipt')
@@ -46,7 +46,7 @@ $: if(payoutOption === 'Repair') {
     maximumPayout = computeReplaceMaxPayout()
   } else if(payoutOption === 'FMV') {
     maximumPayout = computeCashMaxPayout()
-  } else if(claim.event_type === 'Evacuation') {
+  } else if(claim.incident_type === 'Evacuation') {
     maximumPayout = formatMoney(item.coverage_amount * 2/3) || ''
   }
 
@@ -137,7 +137,7 @@ function onDeleted(event) {
     <Banner background="var(--mdc-theme-status-info-bg)"
       color="var(--mdc-theme-status-info)"
       class="max-content-width">
-      <b>{claim.event_type || ''}</b>
+      <b>{claim.incident_type || ''}</b>
     </Banner>
     <div class="left-detail">{eventDate || ''}</div>
   </Row>
@@ -149,7 +149,7 @@ function onDeleted(event) {
       </ClaimBanner>
     {/if}
     <p>
-      {claim.event_description || ''}
+      {claim.incident_description || ''}
     </p>
     <p>
       <b>Covered value</b><br />

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -27,7 +27,7 @@ $: claimItem = claim.claim_items?.[0] || {} as ClaimItem //For now there will on
 $: items = $itemsByPolicyId[$user.policy_id] || []
 $: $user.policy_id && loadItems($user.policy_id)
 $: item = items.find(itm => itm.id === claimItem.item_id) || {} as PolicyItem
-$: eventDate = formatDate(claim.incident_date)
+$: incidentDate = formatDate(claim.incident_date)
 $: status = claim.status || ''
 $: payoutOption = claimItem.payout_option
 $: needsRepairReceipt = (status === 'Needs_repair_receipt')
@@ -139,7 +139,7 @@ function onDeleted(event) {
       class="max-content-width">
       <b>{claim.incident_type || ''}</b>
     </Banner>
-    <div class="left-detail">{eventDate || ''}</div>
+    <div class="left-detail">{incidentDate || ''}</div>
   </Row>
   <Row cols="9">
     <ClaimBanner claimStatus={status} />

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -94,7 +94,7 @@ th {
               <a href="/claims/{claim.id}">{claim.reference_number || ''}</a>
               ({claim.status})
             </Datatable.Data.Row.Item>
-            <Datatable.Data.Row.Item>{formatFriendlyDate(claim.event_date)}</Datatable.Data.Row.Item>
+            <Datatable.Data.Row.Item>{formatFriendlyDate(claim.incident_date)}</Datatable.Data.Row.Item>
             <Datatable.Data.Row.Item>{claimItem.status || ''}</Datatable.Data.Row.Item>
             <Datatable.Data.Row.Item>{claimItem.is_repairable ? 'Yes' : 'No'}</Datatable.Data.Row.Item>
             <Datatable.Data.Row.Item>{claimItem.payout_option || ''}</Datatable.Data.Row.Item>


### PR DESCRIPTION
### Fixed
- Change "claim event"-related names to "claim incident"-related names
- Remove completed TODO comment

### Changed
- In "data/claims" file, rename `ClaimIncidentType` to `ClaimIncidentTypeName` to reflect that it's the name, not the full object, and avoid type-name conflict with `ClaimIncidentType` object structure