### PR TITLE
simplify Menu closing

### DIFF
--- a/src/components/AppHeader.svelte
+++ b/src/components/AppHeader.svelte
@@ -66,7 +66,7 @@ img {
       {/if}
     </button>
 
-    <Menu bind:menuOpen {menuItems} on:syncToggler={() => menuOpen = false}/>
+    <Menu bind:menuOpen {menuItems} />
   </div>
 </header>
 

--- a/src/components/mdc/Menu/Menu.svelte
+++ b/src/components/mdc/Menu/Menu.svelte
@@ -1,17 +1,14 @@
 <!-- https://github.com/material-components/material-components-web/tree/master/packages/mdc-menu -->
 <script lang="ts">
-import { onDestroy, onMount } from 'svelte'
 import { MDCMenu } from '@material/menu'
-import { createEventDispatcher } from 'svelte'
-import { goto } from '@roxi/routify';
+import { goto } from '@roxi/routify'
+import { onMount } from 'svelte'
 
 export let menuItems = []
 export let menuOpen = false
 
 let menu = {}
 let element = {}
-
-const dispatch = createEventDispatcher()
 
 $: currentUrl = window.location.pathname
 $: menu.open = menuOpen
@@ -22,10 +19,6 @@ onMount(() => {
   menu.setDefaultFocusState() //TODO figure out how to use this method and set focus
 
   return () => menu.destroy()
-})
-
-onDestroy(() => {
-  dispatch('syncToggler')
 })
 
 const isMenuItemActive = (currentUrl, menuItemUrl) => currentUrl === menuItemUrl

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -118,7 +118,7 @@ const onEditClaim = event => {
                     <path fill="currentColor" d="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z" />
                   </svg>
                   <!--TODO FUTURE: make this show above the more vert icon when it is in the lower half of the page-->
-                  <div class="item-menu"><Menu bind:menuOpen={shownMenus[item.id]} menuItems="{menuItems(item.id)}" on:syncToggler={() => shownMenus[item.id] = false}/></div>
+                  <div class="item-menu"><Menu bind:menuOpen={shownMenus[item.id]} menuItems="{menuItems(item.id)}" /></div>
                 </Datatable.Data.Row.Item>
               </Datatable.Data.Row>
           {/each}


### PR DESCRIPTION
While reviewing the Menu ui-components PR I realized the syncToggler event isn't needed and doesn't fire.