### PR TITLE
Return an empty string from `formatMoney()` if cents are NaN

### DIFF
--- a/src/helpers/money.ts
+++ b/src/helpers/money.ts
@@ -7,7 +7,7 @@ export const convertToCents = dollars => {
 }
 
 export const formatMoney = cents => {
-  if (cents === undefined || Number.isNaN(cents)) {
+  if (!cents || !Number.isFinite(+cents)) {
     return ''
   }
   return '$' + Number(cents / 100).toFixed(2)

--- a/src/helpers/money.ts
+++ b/src/helpers/money.ts
@@ -7,7 +7,7 @@ export const convertToCents = dollars => {
 }
 
 export const formatMoney = cents => {
-  if (cents === undefined) {
+  if (cents === undefined || Number.isNaN(cents)) {
     return ''
   }
   return '$' + Number(cents / 100).toFixed(2)


### PR DESCRIPTION
### Fixed
- Return an empty string from `formatMoney()` if cents are NaN