### PR TITLE
Hide file claim and refactor states

### DIFF
--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 import ClaimCardBanner from './ClaimCardBanner.svelte'
 import { day } from './const'
-import { getState, Claim, ClaimItem, State } from '../data/claims'
+import type { Claim, ClaimItem } from '../data/claims'
+import { getState, State } from '../data/states'
 import type { PolicyItem } from '../data/items'
 import { Card, Button } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'

--- a/src/components/ClaimCardBanner.svelte
+++ b/src/components/ClaimCardBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { State } from '../data/claims'
+import type { State } from '../data/states'
 
 export let state = {} as State
 export let statusReason = '' as string
@@ -7,7 +7,7 @@ export let statusReason = '' as string
 $: bgColor = state.bgColor || ''
 $: color = state.color || ''
 $: icon = state.icon || ''
-$: title = state.title || ''
+$: title = state.title.claim || ''
 $: steward = statusReason ? 'From your claim handler' : ('' as string) //TODO get this from the api
 </script>
 

--- a/src/components/banners/ClaimBanner.svelte
+++ b/src/components/banners/ClaimBanner.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
 import { Banner } from '../../components'
-import { getState, State, Status } from '../../data/states'
+import { getState, State } from '../../data/states'
 
-export let claimStatus = '' as Status
+export let claimStatus = ''
+export let isClaim: boolean = false
 
 $: state = (claimStatus && getState(claimStatus)) || ({} as State)
 
 $: bgColor = state.bgColor || ''
 $: color = state.color || ''
 $: icon = state.icon || ''
-$: title = state.title || ''
+$: title = isClaim ? state.title.claim : state.title.item || ''
 </script>
 
 <style>

--- a/src/components/banners/ClaimBanner.svelte
+++ b/src/components/banners/ClaimBanner.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { Banner } from '../../components'
-import { getState, State } from '../../data/claims'
+import { getState, State, Status } from '../../data/states'
 
-export let claimStatus = ''
+export let claimStatus = '' as Status
 
 $: state = (claimStatus && getState(claimStatus)) || ({} as State)
 

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -80,12 +80,12 @@ export type CreateClaimRequestBody = {
 }
 
 export type CreateClaimItemRequestBody = {
-  fmv: number
+  fmv: number | null
   is_repairable: boolean
   item_id: string
   payout_option: PayoutOption
-  repair_estimate: number
-  replace_estimate: number
+  repair_estimate: number | null
+  replace_estimate: number | null
 }
 
 export type UpdateClaimRequestBody = {
@@ -110,81 +110,17 @@ export type ClaimsFileAttachResponseBody = {
 }
 
 export type UpdateClaimItemRequestBody = {
-  fmv: number
+  fmv: number | null
   is_repairable: boolean
   payout_option: PayoutOption
-  repair_estimate: number
-  replace_estimate: number
-  repair_actual: number
-  replace_actual: number
-}
-
-export type State = {
-  icon: string
-  color: string
-  bgColor: string
-  title: string
+  repair_estimate: number | null
+  replace_estimate: number | null
+  repair_actual: number | null
+  replace_actual: number | null
 }
 
 export const claims = writable<Claim[]>([])
 export const initialized = writable<boolean>(false)
-export const warning: State = {
-  icon: 'error',
-  color: '--mdc-theme-status-warning',
-  bgColor: '--mdc-theme-status-warning-bg',
-  title: 'Needs changes',
-}
-export const success: State = {
-  icon: 'done',
-  color: '--mdc-theme-status-success',
-  bgColor: '--mdc-theme-status-success-bg',
-  title: 'Approved for repair',
-}
-export const pending: State = {
-  icon: 'watch_later',
-  color: '--mdc-theme-neutral-variant',
-  bgColor: '--mdc-theme-neutral-bg',
-  title: 'Awaiting review',
-}
-export const states: { [stateName: string]: State } = {
-  Revision: {
-    icon: 'chat',
-    color: '--mdc-theme-primary',
-    bgColor: '--mdc-theme-primary-header-bg',
-    title: '',
-  },
-  Draft: {
-    icon: 'edit',
-    color: '--mdc-theme-primary',
-    bgColor: '--mdc-theme-primary-header-bg',
-    title: 'Draft',
-  },
-  Draft2: warning,
-  Pending: pending,
-  Receipt: success,
-  Receipt2: warning,
-  Review1: pending,
-  Review2: pending,
-  Review3: pending,
-  Denied: {
-    icon: 'remove_circle',
-    color: '--mdc-theme-status-error',
-    bgColor: '--mdc-theme-status-error-bg',
-    title: 'Denied',
-  },
-  Approved: {
-    icon: 'paid',
-    color: '--mdc-theme-status-success',
-    bgColor: '--mdc-theme-status-success-bg',
-    title: 'Approved for payout',
-  },
-  Paid: {
-    icon: 'paid',
-    color: '--mdc-theme-status-success',
-    bgColor: '--mdc-theme-status-success-bg',
-    title: 'Complete',
-  },
-}
 
 // TODO: add backend endpoints when they get finished
 // TODO: uncomment when backend has claims endpoints
@@ -201,7 +137,7 @@ export function init() {
  * @param {Object} claimData
  * @return {Object} -- The newly created Claim
  */
-export async function createClaim(item: PolicyItem, claimData) {
+export async function createClaim(item: PolicyItem, claimData: any) {
   const urlPath = `policies/${item.policy_id}/claims`
   start(urlPath)
 
@@ -211,7 +147,7 @@ export async function createClaim(item: PolicyItem, claimData) {
     incident_type: claimData.lossReason,
   }
 
-  const claim = await CREATE<Claim>(urlPath, parsedClaim)
+  const claim = await CREATE<Claim>(urlPath, parsedClaim as any)
 
   claims.update((currClaims) => {
     currClaims.push(claim)
@@ -222,7 +158,7 @@ export async function createClaim(item: PolicyItem, claimData) {
   return claim
 }
 
-export const createClaimItem = async (claimId: string, claimItemData) => {
+export const createClaimItem = async (claimId: string, claimItemData: any) => {
   const urlPath = `claims/${claimId}/items`
   start(urlPath)
   try {
@@ -235,7 +171,7 @@ export const createClaimItem = async (claimId: string, claimItemData) => {
       replace_estimate: convertToCents(claimItemData.replaceEstimateUSD),
     }
 
-    const claimItem = await CREATE<ClaimItem>(urlPath, parsedClaimItem)
+    const claimItem = await CREATE<ClaimItem>(urlPath, parsedClaimItem as any)
 
     claims.update((claims) => {
       const claim = claims.find((c) => c.id === claimId)
@@ -257,7 +193,7 @@ export const createClaimItem = async (claimId: string, claimItemData) => {
  * @param {String} claimId
  * @param {Object} newClaimData
  */
-export async function updateClaim(claimId: string, newClaimData) {
+export async function updateClaim(claimId: string, newClaimData: any) {
   start(claimId)
 
   const parsedData: UpdateClaimRequestBody = {
@@ -286,7 +222,7 @@ export async function claimsFileAttach(claimId: string, fileId: string, purpose:
     file_id: fileId,
     purpose,
   }
-  await CREATE<ClaimsFileAttachResponseBody>(`claims/${claimId}/files`, data)
+  await CREATE<ClaimsFileAttachResponseBody>(`claims/${claimId}/files`, data as any)
 
   stop(fileId)
 }
@@ -307,7 +243,7 @@ export async function submitClaim(claimId: string) {
  * @export
  * @param {Number} itemId
  */
-export async function updateClaimItem(claimItemId: string, claimItemData) {
+export async function updateClaimItem(claimItemId: string, claimItemData: any) {
   start(claimItemId)
 
   const parsedData: UpdateClaimItemRequestBody = {
@@ -353,11 +289,4 @@ export async function loadClaims() {
 
   stop('loadClaims')
   initialized.set(true)
-}
-
-export const getState = (status: string) => {
-  if (states[status] === undefined) {
-    console.error('No such state (for claim status):', status, Object.keys(states))
-  }
-  return states[status || 'Message']
 }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -118,7 +118,7 @@ export async function addItem(policyId: string, itemData: any) {
     serial_number: itemData.uniqueIdentifier,
   }
 
-  const addedItem = await CREATE<PolicyItem>(urlPath, parsedItemData)
+  const addedItem = await CREATE<PolicyItem>(urlPath, parsedItemData as any)
 
   itemsByPolicyId.update((data) => {
     const items = data[policyId] || []

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -98,8 +98,8 @@ export async function loadItems(policyId: string) {
  * @param {Object} itemData
  * @return {Object}
  */
-export async function addItem(policyId: string, itemData) {
-  const urlPath = `policies/${policyId}/items`
+export async function addItem(policyId: string, itemData: any) {
+  const urlPath: string = `policies/${policyId}/items`
   start(urlPath)
 
   const parsedItemData: CreatePolicyItemRequestBody = {
@@ -160,7 +160,7 @@ export async function submitItem(policyId: string, itemId: string) {
  * @param {Object} itemData
  * @return {Object}
  */
-export async function updateItem(policyId: string, itemId: string, itemData) {
+export async function updateItem(policyId: string, itemId: string, itemData: any) {
   if (!itemId) {
     throwError('item id not set')
   }
@@ -206,7 +206,7 @@ export async function updateItem(policyId: string, itemId: string, itemData) {
  * @param {string} policyId -- The UUID for the applicable policy
  * @param {string} itemId -- The UUID for the item to delete
  */
-export async function deleteItem(policyId, itemId) {
+export async function deleteItem(policyId: string, itemId: string) {
   const urlPath = `items/${itemId}`
   start(urlPath)
 

--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -2,43 +2,47 @@ import type { ClaimStatus } from './claims'
 import type { ItemCoverageStatus } from './items'
 
 export type Status = ClaimStatus | ItemCoverageStatus
+export type Title = {
+  claim: string
+  item: string | null
+}
 export type State = {
   icon: string
   color: string
   bgColor: string
-  title: string
+  title: Title
 }
 
 export const warning: State = {
   icon: 'error',
   color: '--mdc-theme-status-warning',
   bgColor: '--mdc-theme-status-warning-bg',
-  title: 'Needs changes',
+  title: { claim: 'Needs changes', item: 'Needs changes' },
 }
 export const success: State = {
   icon: 'done',
   color: '--mdc-theme-status-success',
   bgColor: '--mdc-theme-status-success-bg',
-  title: 'Approved for repair',
+  title: { claim: 'Approved for repair', item: 'Approved' },
 }
 export const pending: State = {
   icon: 'watch_later',
   color: '--mdc-theme-neutral-variant',
   bgColor: '--mdc-theme-neutral-bg',
-  title: 'Awaiting review',
+  title: { claim: 'Awaiting review', item: null },
 }
 export const states: { [stateName: string]: State } = {
   Revision: {
     icon: 'chat',
     color: '--mdc-theme-primary',
     bgColor: '--mdc-theme-primary-header-bg',
-    title: '',
+    title: { claim: '', item: null },
   },
   Draft: {
     icon: 'edit',
     color: '--mdc-theme-primary',
     bgColor: '--mdc-theme-primary-header-bg',
-    title: 'Draft',
+    title: { claim: 'Draft', item: 'Draft' },
   },
   Draft2: warning,
   Pending: pending,
@@ -51,23 +55,23 @@ export const states: { [stateName: string]: State } = {
     icon: 'remove_circle',
     color: '--mdc-theme-status-error',
     bgColor: '--mdc-theme-status-error-bg',
-    title: 'Denied',
+    title: { claim: 'Denied', item: 'Denied' },
   },
   Approved: {
     icon: 'paid',
     color: '--mdc-theme-status-success',
     bgColor: '--mdc-theme-status-success-bg',
-    title: 'Approved for payout',
+    title: { claim: 'Approved for payout', item: 'Approved' },
   },
   Paid: {
     icon: 'paid',
     color: '--mdc-theme-status-success',
     bgColor: '--mdc-theme-status-success-bg',
-    title: 'Complete',
+    title: { claim: 'Complete', item: null },
   },
 }
 
-export const getState = <State>(status: Status) => {
+export const getState = <State>(status: string) => {
   if (states[status] === undefined) {
     console.error('No such state (for claim status):', status, Object.keys(states))
   }

--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -1,0 +1,75 @@
+import type { ClaimStatus } from './claims'
+import type { ItemCoverageStatus } from './items'
+
+export type Status = ClaimStatus | ItemCoverageStatus
+export type State = {
+  icon: string
+  color: string
+  bgColor: string
+  title: string
+}
+
+export const warning: State = {
+  icon: 'error',
+  color: '--mdc-theme-status-warning',
+  bgColor: '--mdc-theme-status-warning-bg',
+  title: 'Needs changes',
+}
+export const success: State = {
+  icon: 'done',
+  color: '--mdc-theme-status-success',
+  bgColor: '--mdc-theme-status-success-bg',
+  title: 'Approved for repair',
+}
+export const pending: State = {
+  icon: 'watch_later',
+  color: '--mdc-theme-neutral-variant',
+  bgColor: '--mdc-theme-neutral-bg',
+  title: 'Awaiting review',
+}
+export const states: { [stateName: string]: State } = {
+  Revision: {
+    icon: 'chat',
+    color: '--mdc-theme-primary',
+    bgColor: '--mdc-theme-primary-header-bg',
+    title: '',
+  },
+  Draft: {
+    icon: 'edit',
+    color: '--mdc-theme-primary',
+    bgColor: '--mdc-theme-primary-header-bg',
+    title: 'Draft',
+  },
+  Draft2: warning,
+  Pending: pending,
+  Receipt: success,
+  Receipt2: warning,
+  Review1: pending,
+  Review2: pending,
+  Review3: pending,
+  Denied: {
+    icon: 'remove_circle',
+    color: '--mdc-theme-status-error',
+    bgColor: '--mdc-theme-status-error-bg',
+    title: 'Denied',
+  },
+  Approved: {
+    icon: 'paid',
+    color: '--mdc-theme-status-success',
+    bgColor: '--mdc-theme-status-success-bg',
+    title: 'Approved for payout',
+  },
+  Paid: {
+    icon: 'paid',
+    color: '--mdc-theme-status-success',
+    bgColor: '--mdc-theme-status-success-bg',
+    title: 'Complete',
+  },
+}
+
+export const getState = <State>(status: Status) => {
+  if (states[status] === undefined) {
+    console.error('No such state (for claim status):', status, Object.keys(states))
+  }
+  return states[status || 'Message']
+}

--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -29,7 +29,7 @@ export const pending: State = {
   icon: 'watch_later',
   color: '--mdc-theme-neutral-variant',
   bgColor: '--mdc-theme-neutral-bg',
-  title: { claim: 'Awaiting review', item: null },
+  title: { claim: 'Awaiting review', item: 'Awaiting item coverage review' },
 }
 export const states: { [stateName: string]: State } = {
   Revision: {

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -28,6 +28,7 @@ import {
   submitClaim,
 } from '../../data/claims'
 import { loadItems, itemsByPolicyId, PolicyItem } from '../../data/items'
+import type { Status } from '../../data/states'
 import { formatMoney } from '../../helpers/money'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
@@ -50,7 +51,7 @@ $: claim.policy_id && loadItems(claim.policy_id)
 $: item = items.find((itm) => itm.id === claimItem.item_id) || ({} as PolicyItem)
 
 $: incidentDate = formatDate(claim.incident_date)
-$: status = claim.status || ''
+$: status = (claim.status || '') as Status
 $: payoutOption = claimItem.payout_option as PayoutOption
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: needsReplaceReceipt = needsReceipt && payoutOption === 'Replacement'
@@ -163,9 +164,9 @@ function onDeleted(event) {
       <div class="left-detail">{incidentDate || ''}</div>
     </Row>
     <Row cols="9">
-      <ClaimBanner claimStatus={status}>{claim.status_reason || ''}</ClaimBanner>
+      <ClaimBanner isClaim claimStatus={status}>{claim.status_reason || ''}</ClaimBanner>
       {#if needsFile}
-        <ClaimBanner claimStatus={`${status}2`}>
+        <ClaimBanner isClaim claimStatus={`${status}2`}>
           Upload {uploadLabel} to get reimbursed.
         </ClaimBanner>
       {/if}

--- a/src/pages/items/[itemId].svelte
+++ b/src/pages/items/[itemId].svelte
@@ -4,7 +4,7 @@ import { Banner, Breadcrumb, ClaimBanner, Row } from '../../components'
 import { day } from '../../components/const'
 import { formatDate } from '../../components/dates'
 import { loading } from '../../components/progress'
-import { itemsByPolicyId, loadItems, PolicyItem } from '../../data/items'
+import { itemsByPolicyId, loadItems, PolicyItem, ItemCoverageStatus } from '../../data/items'
 import { init, policies, Policy } from '../../data/policies'
 import { formatMoney } from '../../helpers/money'
 import { goto } from '@roxi/routify'
@@ -26,6 +26,7 @@ $: policy.household_id && setPolicyHouseholdId()
 $: items = $itemsByPolicyId[$user.policy_id] || []
 $: item = items.find((itm) => itm.id === itemId) || ({} as PolicyItem)
 $: itemName = item.name || ''
+$: status = (item.coverage_status || '') as ItemCoverageStatus
 
 $: msAgo = now - Date.parse(item.updated_at)
 $: daysAgo = msAgo > 0 ? Math.floor(msAgo / day) : '-'
@@ -77,7 +78,7 @@ const goToNewClaim = () => {
     </Row>
 
     <Row cols={'9'}>
-      <ClaimBanner claimStatus={item.coverage_status}>Submitted {daysAgo} days ago</ClaimBanner>
+      <ClaimBanner claimStatus={status}>Submitted {daysAgo} days ago</ClaimBanner>
       <h3>{item.make || ''} {item.model || ''}</h3>
       <b class="mb-6px">Unique ID</b>
       <div>{item.serial_number}</div>
@@ -93,7 +94,9 @@ const goToNewClaim = () => {
       </div>
       <br />
       <div>
-        <Button class="mdc-theme--secondary-background" on:click={goToNewClaim} raised>File Claim</Button>
+        {#if status === 'Approved'}
+          <Button class="mdc-theme--secondary-background" on:click={goToNewClaim} raised>File Claim</Button>
+        {/if}
       </div>
     </Row>
   {/if}

--- a/src/pages/items/[itemId].svelte
+++ b/src/pages/items/[itemId].svelte
@@ -60,7 +60,9 @@ const goToNewClaim = () => {
         <Breadcrumb links={breadcrumbLinks} />
         <div>
           <Button class="remove-button mx-5px" url={`/items/${itemId}/delete`}>Remove</Button>
-          <Button on:click={goToEditItem}>Edit Item</Button>
+          {#if status === 'Draft' || status === 'Pending'}
+            <Button on:click={goToEditItem}>Edit Item</Button>
+          {/if}
         </div>
       </div>
     </Row>


### PR DESCRIPTION
### Changed
- Moved states from claims.ts to states.ts
- gave states.title claim and item properties as they often differ
- Items view - hide File Claim button unless 'Approved' and only show Edit Item on Draft or Pending

### Fixed
- a number of ts errors