### PR TITLE
Claim actions for Steward at "Review1" status

### DIFF
--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -1,29 +1,67 @@
 <script lang="ts">
 import user from '../authn/user'
 import { Claim, ClaimStatus, editableStatuses } from '../data/claims'
-import { Button } from '@silintl/ui-components'
+import { Button, TextField } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
+import Description from './Description.svelte'
 
 export let claim = {} as Claim
 
 const dispatch = createEventDispatcher()
 
+let message = ''
 let status: ClaimStatus
 $: status = claim.status
 
 let isEditable = false
 $: isEditable = editableStatuses.includes(status)
 
-const onEdit = () => dispatch('edit')
-const onSubmit = () => dispatch('submit')
+const on = (eventType) => () => dispatch(eventType)
 </script>
 
-{#if $user.app_role === 'User'}
+<style>
+.container {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr auto;
+}
+.text-input {
+  grid-column: 1 / span 2;
+  grid-row-start: 1;
+}
+.left-buttons {
+  grid-column-start: 1;
+  grid-row-start: 2;
+}
+.right-buttons {
+  grid-column-start: 2;
+  grid-row-start: 2;
+  text-align: right;
+}
+</style>
+
+{#if $user.app_role === 'Steward'}
+  {#if claim.status === 'Review1'}
+    <div class="container">
+      <div class="text-input">
+        <TextField class="w-100" label="Send a message" bind:value={message} />
+        <Description>A message is required to deny or ask for changes.</Description>
+      </div>
+      <div class="left-buttons">
+        <Button on:click={on('deny')} disabled={!message} outlined>Deny</Button>
+      </div>
+      <div class="right-buttons">
+        <Button class="mx-1" on:click={on('ask-for-changes')} disabled={!message} raised>Ask for Changes</Button>
+        <Button on:click={on('approve')} raised>Approve</Button>
+      </div>
+    </div>
+  {/if}
+{:else if $user.app_role === 'User'}
   {#if isEditable}
-    <Button on:click={onEdit} outlined>Edit claim</Button>
+    <Button on:click={on('edit')} outlined>Edit claim</Button>
   {/if}
 
   {#if status === 'Draft' || status === 'Receipt'}
-    <Button raised on:click={onSubmit}>Submit claim</Button>
+    <Button raised on:click={on('submit')}>Submit claim</Button>
   {/if}
 {/if}

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -63,7 +63,7 @@ const onDeny = () => dispatch('deny', message)
     <Button on:click={on('edit')} outlined>Edit claim</Button>
   {/if}
 
-  {#if status === 'Draft' || status === 'Receipt'}
+  {#if status === 'Draft' || status === 'Receipt' || status === 'Revision'}
     <Button raised on:click={on('submit')}>Submit claim</Button>
   {/if}
 {/if}

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -18,6 +18,7 @@ $: isEditable = editableStatuses.includes(status)
 
 const on = (eventType) => () => dispatch(eventType)
 const onAskForChanges = () => dispatch('ask-for-changes', message)
+const onDeny = () => dispatch('deny', message)
 </script>
 
 <style>
@@ -49,7 +50,7 @@ const onAskForChanges = () => dispatch('ask-for-changes', message)
         <Description>A message is required to deny or ask for changes.</Description>
       </div>
       <div class="left-buttons">
-        <Button on:click={on('deny')} disabled={!message} outlined>Deny</Button>
+        <Button on:click={onDeny} disabled={!message} outlined>Deny</Button>
       </div>
       <div class="right-buttons">
         <Button class="mx-1" on:click={onAskForChanges} disabled={!message} raised>Ask for Changes</Button>

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import user from '../authn/user'
 import { Claim, ClaimStatus, editableStatuses } from '../data/claims'
 import { Button } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
@@ -17,10 +18,12 @@ const onEditClaim = () => dispatch('edit')
 const onSubmitClaim = () => dispatch('submit')
 </script>
 
-{#if isEditable}
-  <Button on:click={onEditClaim} outlined>Edit claim</Button>
-{/if}
+{#if $user.app_role === 'User'}
+  {#if isEditable}
+    <Button on:click={onEditClaim} outlined>Edit claim</Button>
+  {/if}
 
-{#if status === 'Draft' || status === 'Receipt'}
-  <Button raised on:click={onSubmitClaim}>Submit claim</Button>
+  {#if status === 'Draft' || status === 'Receipt'}
+    <Button raised on:click={onSubmitClaim}>Submit claim</Button>
+  {/if}
 {/if}

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -14,16 +14,16 @@ $: status = claim.status
 let isEditable = false
 $: isEditable = editableStatuses.includes(status)
 
-const onEditClaim = () => dispatch('edit')
-const onSubmitClaim = () => dispatch('submit')
+const onEdit = () => dispatch('edit')
+const onSubmit = () => dispatch('submit')
 </script>
 
 {#if $user.app_role === 'User'}
   {#if isEditable}
-    <Button on:click={onEditClaim} outlined>Edit claim</Button>
+    <Button on:click={onEdit} outlined>Edit claim</Button>
   {/if}
 
   {#if status === 'Draft' || status === 'Receipt'}
-    <Button raised on:click={onSubmitClaim}>Submit claim</Button>
+    <Button raised on:click={onSubmit}>Submit claim</Button>
   {/if}
 {/if}

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -17,6 +17,7 @@ let isEditable: boolean
 $: isEditable = editableStatuses.includes(status)
 
 const on = (eventType) => () => dispatch(eventType)
+const onAskForChanges = () => dispatch('ask-for-changes', message)
 </script>
 
 <style>
@@ -51,7 +52,7 @@ const on = (eventType) => () => dispatch(eventType)
         <Button on:click={on('deny')} disabled={!message} outlined>Deny</Button>
       </div>
       <div class="right-buttons">
-        <Button class="mx-1" on:click={on('ask-for-changes')} disabled={!message} raised>Ask for Changes</Button>
+        <Button class="mx-1" on:click={onAskForChanges} disabled={!message} raised>Ask for Changes</Button>
         <Button on:click={on('approve')} raised>Approve</Button>
       </div>
     </div>

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -13,7 +13,7 @@ let message = ''
 let status: ClaimStatus
 $: status = claim.status
 
-let isEditable = false
+let isEditable: boolean
 $: isEditable = editableStatuses.includes(status)
 
 const on = (eventType) => () => dispatch(eventType)

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Claim } from '../data/claims'
+import { Claim, ClaimStatus, editableStatuses } from '../data/claims'
 import { Button } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
@@ -7,11 +7,11 @@ export let claim = {} as Claim
 
 const dispatch = createEventDispatcher()
 
-let status: string
+let status: ClaimStatus
 $: status = claim.status
 
 let isEditable = false
-$: isEditable = status !== 'Approved' && status !== 'Denied' && status !== 'Paid'
+$: isEditable = editableStatuses.includes(status)
 
 const onEditClaim = () => dispatch('edit')
 const onSubmitClaim = () => dispatch('submit')

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -185,6 +185,7 @@ export const states: { [stateName: string]: State } = {
     title: 'Complete',
   },
 }
+export const editableStatuses: ClaimStatus[] = ['Draft', 'Review1', 'Review2', 'Review3', 'Revision', 'Receipt']
 
 // TODO: add backend endpoints when they get finished
 // TODO: uncomment when backend has claims endpoints

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -123,6 +123,10 @@ export type ClaimsRequestRevisionRequestBody = {
   status_reason: string
 }
 
+export type DenyClaimRequestBody = {
+  status_reason: string
+}
+
 export type State = {
   icon: string
   color: string
@@ -322,6 +326,28 @@ export const requestRevision = async (claimId: string, reason: string): Promise<
   })
 
   return modifiedClaim
+}
+
+/**
+ * Deny a claim.
+ *
+ * @export
+ * @param {String} claimId
+ * @param {String} reason -- A message from a reviewer detailing the reason for the denial.
+ */
+export const denyClaim = async (claimId: string, reason: string): Promise<Claim> => {
+  const requestBody: DenyClaimRequestBody = {
+    status_reason: reason,
+  }
+  const deniedClaim = await CREATE<Claim>(`claims/${claimId}/deny`, requestBody)
+
+  claims.update((claims) => {
+    const i = claims.findIndex((claim) => claim.id === claimId)
+    claims[i] = deniedClaim
+    return claims
+  })
+
+  return deniedClaim
 }
 
 export async function claimsFileAttach(claimId: string, fileId: string, purpose: ClaimFilePurpose) {

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -119,6 +119,10 @@ export type UpdateClaimItemRequestBody = {
   replace_actual: number
 }
 
+export type ClaimsRequestRevisionRequestBody = {
+  status_reason: string
+}
+
 export type State = {
   icon: string
   color: string
@@ -296,6 +300,28 @@ export const approveClaim = async (claimId: string): Promise<Claim> => {
   })
 
   return approvedClaim
+}
+
+/**
+ * Request revisions to a claim.
+ *
+ * @export
+ * @param {String} claimId
+ * @param {String} reason -- A message from a reviewer detailing the revisions needed.
+ */
+export const requestRevision = async (claimId: string, reason: string): Promise<Claim> => {
+  const requestBody: ClaimsRequestRevisionRequestBody = {
+    status_reason: reason,
+  }
+  const modifiedClaim = await CREATE<Claim>(`claims/${claimId}/revision`, requestBody)
+
+  claims.update((claims) => {
+    const i = claims.findIndex((claim) => claim.id === claimId)
+    claims[i] = modifiedClaim
+    return claims
+  })
+
+  return modifiedClaim
 }
 
 export async function claimsFileAttach(claimId: string, fileId: string, purpose: ClaimFilePurpose) {

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -280,6 +280,24 @@ export async function updateClaim(claimId: string, newClaimData) {
   return updatedClaim
 }
 
+/**
+ * Approve a claim.
+ *
+ * @export
+ * @param {String} claimId
+ */
+export const approveClaim = async (claimId: string): Promise<Claim> => {
+  const updatedClaim = await UPDATE<Claim>(`claims/${claimId}/approve`)
+
+  claims.update((claims) => {
+    const i = claims.findIndex((claim) => claim.id === claimId)
+    claims[i] = updatedClaim
+    return claims
+  })
+
+  return updatedClaim
+}
+
 export async function claimsFileAttach(claimId: string, fileId: string, purpose: ClaimFilePurpose) {
   start(fileId)
 

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -287,15 +287,15 @@ export async function updateClaim(claimId: string, newClaimData) {
  * @param {String} claimId
  */
 export const approveClaim = async (claimId: string): Promise<Claim> => {
-  const updatedClaim = await UPDATE<Claim>(`claims/${claimId}/approve`)
+  const approvedClaim = await CREATE<Claim>(`claims/${claimId}/approve`)
 
   claims.update((claims) => {
     const i = claims.findIndex((claim) => claim.id === claimId)
-    claims[i] = updatedClaim
+    claims[i] = approvedClaim
     return claims
   })
 
-  return updatedClaim
+  return approvedClaim
 }
 
 export async function claimsFileAttach(claimId: string, fileId: string, purpose: ClaimFilePurpose) {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -12,7 +12,7 @@ type UploadResponseBody = {
   url: string
 }
 
-export async function CREATE<T>(uri: string, body = undefined) {
+export async function CREATE<T>(uri: string, body: any = undefined) {
   return await customFetch<T>('post', uri, body)
 }
 export async function GET<T>(uri: string) {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -18,7 +18,7 @@ export async function CREATE<T>(uri: string, body = undefined) {
 export async function GET<T>(uri: string) {
   return await customFetch<T>('get', uri)
 }
-export async function UPDATE<T>(uri: string, body = undefined) {
+export async function UPDATE<T>(uri: string, body) {
   return await customFetch<T>('put', uri, body)
 }
 export async function DELETE<T>(uri: string) {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -18,7 +18,7 @@ export async function CREATE<T>(uri: string, body = undefined) {
 export async function GET<T>(uri: string) {
   return await customFetch<T>('get', uri)
 }
-export async function UPDATE<T>(uri: string, body) {
+export async function UPDATE<T>(uri: string, body = undefined) {
   return await customFetch<T>('put', uri, body)
 }
 export async function DELETE<T>(uri: string) {

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -15,6 +15,7 @@ import { formatDate } from '../../components/dates'
 import { loading } from '../../components/progress'
 import { upload } from '../../data'
 import {
+  approveClaim,
   loadClaims,
   claims,
   initialized,
@@ -83,6 +84,8 @@ const getUploadLabel = (claimItem: ClaimItem, needsReceipt: boolean, receiptType
 }
 
 const editClaim = () => $goto(`/claims/${claimId}/edit`)
+
+const onApprove = async () => await approveClaim(claimId)
 
 const onSubmit = async () => await submitClaim(claimId)
 
@@ -186,7 +189,7 @@ function onDeleted(event) {
       {/if}
 
       <p>
-        <ClaimActions {claim} on:edit={editClaim} on:submit={onSubmit} />
+        <ClaimActions {claim} on:approve={onApprove} on:edit={editClaim} on:submit={onSubmit} />
       </p>
 
       {#if needsReceipt}

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -16,6 +16,7 @@ import { loading } from '../../components/progress'
 import { upload } from '../../data'
 import {
   approveClaim,
+  denyClaim,
   loadClaims,
   claims,
   initialized,
@@ -91,6 +92,11 @@ const onApprove = async () => await approveClaim(claimId)
 const onAskForChanges = async (event) => {
   const message = event.detail
   await requestRevision(claimId, message)
+}
+
+const onDenyClaim = async (event) => {
+  const message = event.detail
+  await denyClaim(claimId, message)
 }
 
 const onSubmit = async () => await submitClaim(claimId)
@@ -199,6 +205,7 @@ function onDeleted(event) {
           {claim}
           on:approve={onApprove}
           on:ask-for-changes={onAskForChanges}
+          on:deny={onDenyClaim}
           on:edit={editClaim}
           on:submit={onSubmit}
         />

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -26,6 +26,7 @@ import {
   ClaimFile,
   ClaimFilePurpose,
   PayoutOption,
+  requestRevision,
   submitClaim,
 } from '../../data/claims'
 import { loadItems, itemsByPolicyId, PolicyItem } from '../../data/items'
@@ -86,6 +87,11 @@ const getUploadLabel = (claimItem: ClaimItem, needsReceipt: boolean, receiptType
 const editClaim = () => $goto(`/claims/${claimId}/edit`)
 
 const onApprove = async () => await approveClaim(claimId)
+
+const onAskForChanges = async (event) => {
+  const message = event.detail
+  await requestRevision(claimId, message)
+}
 
 const onSubmit = async () => await submitClaim(claimId)
 
@@ -189,7 +195,13 @@ function onDeleted(event) {
       {/if}
 
       <p>
-        <ClaimActions {claim} on:approve={onApprove} on:edit={editClaim} on:submit={onSubmit} />
+        <ClaimActions
+          {claim}
+          on:approve={onApprove}
+          on:ask-for-changes={onAskForChanges}
+          on:edit={editClaim}
+          on:submit={onSubmit}
+        />
       </p>
 
       {#if needsReceipt}


### PR DESCRIPTION
### Added
- Add steward action buttons/input for "Review1" claim status

### Changed
- Move definition of which claim statuses are editable into data/claims.ts

### Fixed
- Let the user (re)submit a claim with a status of "Revision"