### PR TITLE
Use `updateClaimsStore()` in one more place in claims.ts

### DIFF
--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -216,11 +216,7 @@ export async function updateClaim(claimId: string, newClaimData: any): Promise<v
 
   const updatedClaim = await UPDATE<Claim>(`claims/${claimId}`, parsedData)
 
-  claims.update((currClaims) => {
-    const i = currClaims.findIndex((clm) => clm.id === claimId)
-    currClaims[i] = updatedClaim
-    return currClaims
-  })
+  updateClaimsStore(updatedClaim)
 }
 
 /**


### PR DESCRIPTION
### Fixed
- Use `updateClaimsStore()` in one more place in claims.ts

---

This is a follow-up on [this comment](https://github.com/silinternational/cover-ui/pull/155#pullrequestreview-763437478)