### PR TITLE
"Save For Later" button for Claims

### DIFF
--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -1,5 +1,5 @@
 import type { ClaimIncidentType } from '../data/claim-incident-types'
-import type { PayoutOption, ClaimItem } from '../data/claims'
+import type { PayoutOption, ClaimItem, ClaimStatus } from '../data/claims'
 
 export const DEDUCTIBLE = 0.05
 export const LOSS_REASON_EVACUATION = 'Evacuation'
@@ -85,4 +85,10 @@ export const determineMaxPayout = (
     default:
       return undefined
   }
+}
+
+export const isEvidenceNeeded = (claimItem: ClaimItem, claimStatus: ClaimStatus): boolean => {
+  const willNeedEvidence = claimItem.fmv || claimItem.repair_estimate
+  const canProvideEvidenceNow = ['Draft'].includes(claimStatus)
+  return willNeedEvidence && canProvideEvidenceNow
 }

--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -88,7 +88,7 @@ export const determineMaxPayout = (
 }
 
 export const isEvidenceNeeded = (claimItem: ClaimItem, claimStatus: ClaimStatus): boolean => {
-  const willNeedEvidence = claimItem.fmv || claimItem.repair_estimate
+  const willNeedEvidence = claimItem.fmv > 0 || claimItem.repair_estimate > 0
   const canProvideEvidenceNow = ['Draft'].includes(claimStatus)
   return willNeedEvidence && canProvideEvidenceNow
 }

--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -89,6 +89,6 @@ export const determineMaxPayout = (
 
 export const isEvidenceNeeded = (claimItem: ClaimItem, claimStatus: ClaimStatus): boolean => {
   const willNeedEvidence = claimItem.fmv > 0 || claimItem.repair_estimate > 0
-  const canProvideEvidenceNow = ['Draft'].includes(claimStatus)
+  const canProvideEvidenceNow = ['Draft', 'Review1'].includes(claimStatus)
   return willNeedEvidence && canProvideEvidenceNow
 }

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -123,8 +123,18 @@ const determinePayoutOption = (
   return selectedPayoutOption
 }
 
-const onSubmit = async () => {
-  dispatch('submit', {
+const onSubmitClaim = (event: Event) => {
+  event.preventDefault()
+  dispatch('submit', getFormData())
+}
+
+const onSaveForLater = (event: Event) => {
+  event.preventDefault()
+  dispatch('save-for-later', getFormData())
+}
+
+const getFormData = () => {
+  return {
     claimData: {
       lostDate,
       lossReason,
@@ -138,7 +148,7 @@ const onSubmit = async () => {
       replaceEstimateUSD,
       fairMarketValueUSD,
     },
-  })
+  }
 }
 
 const setInitialValues = (claim: Claim, claimItem: ClaimItem) => {
@@ -176,7 +186,7 @@ const unSetReplaceEstimate = () => {
 </script>
 
 <div class="w-50">
-  <Form on:submit={onSubmit}>
+  <Form>
     <p>
       <span class="ml-1">Date lost or damaged</span><br />
       <DateInput class="mt-1" bind:value={lostDate} />
@@ -250,7 +260,8 @@ const unSetReplaceEstimate = () => {
     {/if}
     <!--TODO: add evacuation amount when items is done (covered_value*(2/3))-->
     <p>
-      <Button raised>Submit</Button>
+      <Button on:click={onSaveForLater} outlined>Save For Later</Button>
+      <Button on:click={onSubmitClaim} raised>Submit Claim</Button>
     </p>
   </Form>
 </div>

--- a/src/pages/claims.svelte
+++ b/src/pages/claims.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
 import user from '../authn/user'
 import { ClaimCards, Row, Breadcrumb } from '../components/'
-import { claims, initialized as claimsInitialized, loadClaims } from '../data/claims'
+import { claims, loadClaims } from '../data/claims'
 import { itemsByPolicyId, loadItems } from '../data/items'
 import { Page, Button } from '@silintl/ui-components'
-
-$: $claimsInitialized || loadClaims()
+import { onMount } from 'svelte'
 
 $: policyId = $user.policy_id
 $: policyId && loadItems(policyId)
 $: items = $itemsByPolicyId[policyId] || []
+
+onMount(() => {
+  loadClaims()
+})
 </script>
 
 <Page layout="grid">

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { determineMaxPayout } from '../../business-rules/claim-payout-amount'
+import { determineMaxPayout, isEvidenceNeeded } from '../../business-rules/claim-payout-amount'
 import {
   Banner,
   Breadcrumb,
@@ -59,7 +59,7 @@ $: payoutOption = claimItem.payout_option as PayoutOption
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: needsReplaceReceipt = needsReceipt && payoutOption === 'Replacement'
 $: needsReceipt = claimStatus === 'Receipt'
-$: needsEvidence = ((claimItem.fmv || claimItem.repair_estimate) && status === 'Draft') as boolean
+$: needsEvidence = isEvidenceNeeded(claimItem, claimStatus)
 $: needsFile = (needsReceipt || needsEvidence) as boolean
 $: filePurpose = getFilePurpose(claimItem, needsReceipt)
 $: uploadLabel = getUploadLabel(claimItem, needsReceipt, receiptType) as string

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -54,11 +54,11 @@ $: claim.policy_id && loadItems(claim.policy_id)
 $: item = items.find((itm) => itm.id === claimItem.item_id) || ({} as PolicyItem)
 
 $: incidentDate = formatDate(claim.incident_date)
-$: status = (claim.status || '') as ClaimStatus
+$: claimStatus = (claim.status || '') as ClaimStatus
 $: payoutOption = claimItem.payout_option as PayoutOption
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: needsReplaceReceipt = needsReceipt && payoutOption === 'Replacement'
-$: needsReceipt = status === 'Receipt'
+$: needsReceipt = claimStatus === 'Receipt'
 $: needsEvidence = ((claimItem.fmv || claimItem.repair_estimate) && status === 'Draft') as boolean
 $: needsFile = (needsReceipt || needsEvidence) as boolean
 $: filePurpose = getFilePurpose(claimItem, needsReceipt)
@@ -181,9 +181,9 @@ function onDeleted(event) {
       <div class="left-detail">{incidentDate || ''}</div>
     </Row>
     <Row cols="9">
-      <ClaimBanner claimStatus={status}>{claim.status_reason || ''}</ClaimBanner>
+      <ClaimBanner {claimStatus}>{claim.status_reason || ''}</ClaimBanner>
       {#if needsFile}
-        <ClaimBanner claimStatus={`${status}Secondary`}>
+        <ClaimBanner claimStatus={`${claimStatus}Secondary`}>
           Upload {uploadLabel} to get reimbursed.
         </ClaimBanner>
       {/if}

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -157,11 +157,13 @@ function onDeleted(event) {
 
 <Page layout="grid">
   {#if !item.id}
-    {#if $loading}
-      Loading...
-    {:else}
-      We could not find that claim. Please <a href="/claims">go back</a> and select a claim from the list.
-    {/if}
+    <Row>
+      {#if $loading}
+        Loading...
+      {:else}
+        We could not find that claim. Please <a href="/claims">go back</a> and select a claim from the list.
+      {/if}
+    </Row>
   {:else}
     <Row>
       <Breadcrumb links={breadcrumbLinks} />

--- a/src/pages/claims/[claimId]/edit.svelte
+++ b/src/pages/claims/[claimId]/edit.svelte
@@ -2,7 +2,16 @@
 import user from '../../../authn/user'
 import { Breadcrumb, ClaimForm } from '../../../components'
 import { loading } from '../../../components/progress'
-import { Claim, ClaimItem, claims, initialized, loadClaims, updateClaim, updateClaimItem } from '../../../data/claims'
+import {
+  Claim,
+  ClaimItem,
+  claims,
+  initialized,
+  loadClaims,
+  submitClaim,
+  updateClaim,
+  updateClaimItem,
+} from '../../../data/claims'
 import { itemsByPolicyId, loadItems, PolicyItem } from '../../../data/items'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
@@ -29,11 +38,19 @@ $: thisClaimBreadcrumb = { name: claimName || 'This item', url: `/claims/${claim
 const editBreadcrumb = { name: 'Edit', url: `/claims/${claimId}/edit` }
 $: breadcrumbLinks = [claimsBreadcrumb, thisClaimBreadcrumb, editBreadcrumb]
 
-const onSubmit = async (event: CustomEvent) => {
+const updateClaimAndItem = async (event: CustomEvent): Promise<void> => {
   const { claimData, claimItemData } = event.detail
 
   await updateClaim(claimId, claimData)
   await updateClaimItem(claimId, claimItemId, claimItemData)
+}
+const onSaveForLater = async (event: CustomEvent) => {
+  await updateClaimAndItem(event)
+  $goto(`/claims/${claimId}`)
+}
+const onSubmit = async (event: CustomEvent) => {
+  await updateClaimAndItem(event)
+  await submitClaim(claimId)
   $goto(`/claims/${claimId}`)
 }
 </script>
@@ -52,6 +69,6 @@ const onSubmit = async (event: CustomEvent) => {
   <!-- @todo Handle situations where the user isn't allowed to edit this claim. -->
   <Page>
     <Breadcrumb links={breadcrumbLinks} />
-    <ClaimForm {claim} {item} on:submit={onSubmit} />
+    <ClaimForm {claim} {item} on:save-for-later={onSaveForLater} on:submit={onSubmit} />
   </Page>
 {/if}


### PR DESCRIPTION
### Added
- Add "Save For Later" button to ClaimForm

### Fixed
- Actually submit the claim when "Submit Claim" is clicked while creating/editing
- Fix formatting of "We could not find that claim" message
- Extract `isEvidenceNeeded()` to business rules
- Allow user to provide evidence at `Review1` claim status, too