### PR TITLE
Re-load the user data (after a delay) if we didn't get their policy_id

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { login } from '../authn'
-import { loadUser } from '../authn/user'
+import user, { loadUser } from '../authn/user'
 import type { CustomError } from '../error'
 import './mdc/_index.scss'
 import t from '../i18n'
@@ -8,6 +8,11 @@ import { parse, stringify } from 'qs'
 import { Router } from '@roxi/routify'
 import { onMount } from 'svelte'
 import { routes } from '../../.routify/routes'
+
+// If we've loaded the user, but their policy wasn't quite ready, try again.
+$: if (!$user.policy_id) {
+  setTimeout(loadUser, 5000)
+}
 
 // added because of this:  https://github.com/sveltech/routify/issues/201
 const queryHandler = {


### PR DESCRIPTION
### Fixed
- Ensure "Accountable Persons" list has entries, by re-retrieving the user data if it didn't come back with a policy_id