### PR TITLE
Claim of status: "Draft" redirects to /claimID/edit, "save for later" button redirects to /home

### DIFF
--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -89,6 +89,6 @@ export const determineMaxPayout = (
 
 export const isEvidenceNeeded = (claimItem: ClaimItem, claimStatus: ClaimStatus): boolean => {
   const willNeedEvidence = claimItem.fmv > 0 || claimItem.repair_estimate > 0
-  const canProvideEvidenceNow = ['Draft', 'Review1'].includes(claimStatus)
+  const canProvideEvidenceNow = ['Review1'].includes(claimStatus)
   return willNeedEvidence && canProvideEvidenceNow
 }

--- a/src/components/banners/ClaimBanner.svelte
+++ b/src/components/banners/ClaimBanner.svelte
@@ -8,4 +8,4 @@ export let claimStatus = '' as ClaimStatus
 $: state = (claimStatus && getClaimState(claimStatus)) || ({} as State)
 </script>
 
-<StatusBanner {state}><slot /></StatusBanner>
+<StatusBanner class={$$props.class} {state}><slot /></StatusBanner>

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -55,6 +55,7 @@ $: item = items.find((itm) => itm.id === claimItem.item_id) || ({} as PolicyItem
 
 $: incidentDate = formatDate(claim.incident_date)
 $: claimStatus = (claim.status || '') as ClaimStatus
+$: claimStatus === 'Draft' && editClaim()
 $: payoutOption = claimItem.payout_option as PayoutOption
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: needsReplaceReceipt = needsReceipt && payoutOption === 'Replacement'

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import user from '../../authn/user'
 import { determineMaxPayout, isEvidenceNeeded } from '../../business-rules/claim-payout-amount'
 import {
   Banner,
@@ -55,7 +56,7 @@ $: item = items.find((itm) => itm.id === claimItem.item_id) || ({} as PolicyItem
 
 $: incidentDate = formatDate(claim.incident_date)
 $: claimStatus = (claim.status || '') as ClaimStatus
-$: claimStatus === 'Draft' && editClaim()
+$: claimStatus === 'Draft' && $user.app_role == 'User' && editClaim()
 $: payoutOption = claimItem.payout_option as PayoutOption
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: needsReplaceReceipt = needsReceipt && payoutOption === 'Replacement'

--- a/src/pages/claims/[claimId].svelte
+++ b/src/pages/claims/[claimId].svelte
@@ -56,7 +56,7 @@ $: item = items.find((itm) => itm.id === claimItem.item_id) || ({} as PolicyItem
 
 $: incidentDate = formatDate(claim.incident_date)
 $: claimStatus = (claim.status || '') as ClaimStatus
-$: claimStatus === 'Draft' && $user.app_role == 'User' && editClaim()
+$: claimStatus === 'Draft' && $user.app_role === 'User' && editClaim()
 $: payoutOption = claimItem.payout_option as PayoutOption
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: needsReplaceReceipt = needsReceipt && payoutOption === 'Replacement'

--- a/src/pages/claims/[claimId]/edit.svelte
+++ b/src/pages/claims/[claimId]/edit.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import user from '../../../authn/user'
-import { Breadcrumb, ClaimForm } from '../../../components'
+import { Breadcrumb, ClaimBanner, ClaimForm } from '../../../components'
 import { loading } from '../../../components/progress'
 import {
   Claim,
@@ -46,7 +46,7 @@ const updateClaimAndItem = async (event: CustomEvent): Promise<void> => {
 }
 const onSaveForLater = async (event: CustomEvent) => {
   await updateClaimAndItem(event)
-  $goto(`/claims/${claimId}`)
+  $goto('/home')
 }
 const onSubmit = async (event: CustomEvent) => {
   await updateClaimAndItem(event)
@@ -69,6 +69,7 @@ const onSubmit = async (event: CustomEvent) => {
   <!-- @todo Handle situations where the user isn't allowed to edit this claim. -->
   <Page>
     <Breadcrumb links={breadcrumbLinks} />
+    <ClaimBanner claimStatus={'Draft'} class="my-2" />
     <ClaimForm {claim} {item} on:save-for-later={onSaveForLater} on:submit={onSubmit} />
   </Page>
 {/if}


### PR DESCRIPTION
### Added
- ClaimBanner to /[claimID]/edit.svelte
- `$: claimStatus === 'Draft' && editClaim()` to [ClaimID].svelte
- `$$props.class` to ClaimBanner.svelte
### Changed
- onSaveForLater to redirect to /home
- canProvideEvidenceNow to only include 'Review1'
![draftForm](https://user-images.githubusercontent.com/70765247/135339013-bff2e903-4070-4ec3-8abe-ccf70f143676.gif)