### PR TITLE
"Draft" item view should redirect to edit (with Draft banner), "Save for later" to /home

### DIFF
--- a/src/components/banners/ItemBanner.svelte
+++ b/src/components/banners/ItemBanner.svelte
@@ -8,4 +8,4 @@ export let itemStatus = '' as ItemCoverageStatus
 $: state = (itemStatus && getItemState(itemStatus)) || ({} as State)
 </script>
 
-<StatusBanner {state}><slot /></StatusBanner>
+<StatusBanner class={$$props.class} {state}><slot /></StatusBanner>

--- a/src/pages/items/[itemId].svelte
+++ b/src/pages/items/[itemId].svelte
@@ -53,7 +53,7 @@ $: items = $itemsByPolicyId[$user.policy_id] || []
 $: item = items.find((itm) => itm.id === itemId) || ({} as PolicyItem)
 $: itemName = item.name || ''
 $: status = (item.coverage_status || '') as ItemCoverageStatus
-$: status === 'Draft' && $user.app_role == 'User' && goToEditItem()
+$: status === 'Draft' && $user.app_role === 'User' && goToEditItem()
 
 $: msAgo = now - Date.parse(item.updated_at)
 $: daysAgo = msAgo > 0 ? Math.floor(msAgo / day) : '-'

--- a/src/pages/items/[itemId].svelte
+++ b/src/pages/items/[itemId].svelte
@@ -53,7 +53,7 @@ $: items = $itemsByPolicyId[$user.policy_id] || []
 $: item = items.find((itm) => itm.id === itemId) || ({} as PolicyItem)
 $: itemName = item.name || ''
 $: status = (item.coverage_status || '') as ItemCoverageStatus
-$: status === 'Draft' && goToEditItem()
+$: status === 'Draft' && $user.app_role == 'User' && goToEditItem()
 
 $: msAgo = now - Date.parse(item.updated_at)
 $: daysAgo = msAgo > 0 ? Math.floor(msAgo / day) : '-'

--- a/src/pages/items/[itemId].svelte
+++ b/src/pages/items/[itemId].svelte
@@ -53,6 +53,7 @@ $: items = $itemsByPolicyId[$user.policy_id] || []
 $: item = items.find((itm) => itm.id === itemId) || ({} as PolicyItem)
 $: itemName = item.name || ''
 $: status = (item.coverage_status || '') as ItemCoverageStatus
+$: status === 'Draft' && goToEditItem()
 
 $: msAgo = now - Date.parse(item.updated_at)
 $: daysAgo = msAgo > 0 ? Math.floor(msAgo / day) : '-'

--- a/src/pages/items/[itemId]/edit.svelte
+++ b/src/pages/items/[itemId]/edit.svelte
@@ -5,6 +5,7 @@ import { loading } from '../../../components/progress'
 import { itemsByPolicyId, loadItems, PolicyItem, submitItem, updateItem } from '../../../data/items'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
+import ItemBanner from '../../../components/banners/ItemBanner.svelte'
 
 export let itemId: string
 
@@ -30,7 +31,7 @@ const onSubmit = async (event) => {
 const onSaveForLater = async (event) => {
   await updateItem(policyId, itemId, event.detail)
 
-  $goto(`/items/${itemId}`)
+  $goto('/home')
 }
 </script>
 
@@ -44,6 +45,7 @@ const onSaveForLater = async (event) => {
   <!-- @todo Handle situations where the user isn't allowed to edit this item (if any). -->
   <Page>
     <Breadcrumb links={breadcrumbLinks} />
+    <ItemBanner itemStatus="Draft" class="my-2" />
     <ItemForm {item} {policyId} on:submit={onSubmit} on:save-for-later={onSaveForLater} />
   </Page>
 {/if}

--- a/src/pages/items/[itemId]/edit.svelte
+++ b/src/pages/items/[itemId]/edit.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 import user from '../../../authn/user'
-import { Breadcrumb, ItemForm } from '../../../components'
+import { Breadcrumb, ItemBanner, ItemForm } from '../../../components'
 import { loading } from '../../../components/progress'
 import { itemsByPolicyId, loadItems, PolicyItem, submitItem, updateItem } from '../../../data/items'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
-import ItemBanner from '../../../components/banners/ItemBanner.svelte'
 
 export let itemId: string
 


### PR DESCRIPTION
### Added
- ItemBanner to /[itemID]/edit.svelte
- $: status === 'Draft' && goToEditItem() to [itemID].svelte
- $$props.class to ItemBanner.svelte
### Changed
- onSaveForLater to redirect to /home
-
![DraftItem](https://user-images.githubusercontent.com/70765247/135341187-ec06aa01-523d-4440-ac87-9f55c6e8a7c5.gif)
 