### PR TITLE
Increase button and fallback font weight

### DIFF
--- a/src/components/mdc/_theme.scss
+++ b/src/components/mdc/_theme.scss
@@ -3,24 +3,25 @@
 @include theme.core-styles;
 
 :root {
-  --mdc-theme-primary: #005CB9;
+  --mdc-theme-primary: #005cb9;
   --mdc-theme-primary-variant: #5885b3;
-  --mdc-theme-primary-header-bg: #EEF2FA;
-  --mdc-theme-secondary: #FFB619;
-  --mdc-theme-error: #C30000;
-  --mdc-theme-neutral: #6D7580;
+  --mdc-theme-primary-header-bg: #eef2fa;
+  --mdc-theme-secondary: #ffb619;
+  --mdc-theme-error: #c30000;
+  --mdc-theme-neutral: #6d7580;
   --mdc-theme-neutral-variant: #394452;
-  --mdc-theme-neutral-bg:#EBEEF2;
-  --mdc-theme-neutral-action:hsla(214, 11%, 37%, 1);
-  --progress-bar-color: #005CB9;
-  --mdc-theme-status-warning: #B95000;
-  --mdc-theme-status-warning-bg: #FFF4EC;
-  --mdc-theme-status-error: #DA1414;
-  --mdc-theme-status-error-bg: #FEEFEF;
-  --mdc-theme-status-info: #2E5AAC;
-  --mdc-theme-status-info-bg: #EEF2FA;
+  --mdc-theme-neutral-bg: #ebeef2;
+  --mdc-theme-neutral-action: hsla(214, 11%, 37%, 1);
+  --progress-bar-color: #005cb9;
+  --mdc-theme-status-warning: #b95000;
+  --mdc-theme-status-warning-bg: #fff4ec;
+  --mdc-theme-status-error: #da1414;
+  --mdc-theme-status-error-bg: #feefef;
+  --mdc-theme-status-info: #2e5aac;
+  --mdc-theme-status-info-bg: #eef2fa;
   --mdc-theme-status-success: hsla(134, 52%, 32%, 1);
   --mdc-theme-status-success-bg: hsla(135, 50%, 95%, 1);
+  --mdc-typography-button-font-weight: 700;
 }
 
 .mdc-theme--primary {
@@ -32,7 +33,7 @@
 }
 
 .mdc-theme--neutral {
-  color: var(--mdc-theme-neutral)
+  color: var(--mdc-theme-neutral);
 }
 
 .mdc-theme--secondary-background {
@@ -46,4 +47,8 @@
 .error-button {
   --mdc-theme-primary: var(--mdc-theme-status-error);
   border: 2px solid !important;
+}
+
+.mdc-button {
+  font-weight: var(--mdc-typography-button-font-weight);
 }

--- a/src/components/mdc/_theme.scss
+++ b/src/components/mdc/_theme.scss
@@ -22,6 +22,7 @@
   --mdc-theme-status-success: hsla(134, 52%, 32%, 1);
   --mdc-theme-status-success-bg: hsla(135, 50%, 95%, 1);
   --mdc-typography-button-font-weight: 700;
+  --mdc-typography-select-font-weight: 500;
 }
 
 .mdc-theme--primary {
@@ -49,6 +50,12 @@
   border: 2px solid !important;
 }
 
-.mdc-button {
+.mdc-button,
+.mdc-drawer .mdc-list .mdc-list-item,
+.mdc-menu .mdc-list .mdc-list-item {
   font-weight: var(--mdc-typography-button-font-weight);
+}
+
+.mdc-select__menu .mdc-list .mdc-list-item {
+  font-weight: var(--mdc-typography-select-font-weight);
 }

--- a/src/pages/_fallback.svelte
+++ b/src/pages/_fallback.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 import { notFound } from '../analytics'
-import { Row } from '../components'
-import { Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
 
 onMount(notFound)
@@ -11,15 +9,6 @@ onMount(notFound)
 p {
   text-align: center;
 }
-.typography-button-font-weight {
-  font-weight: var(--mdc-typography-button-font-weight);
-}
 </style>
 
-<Page>
-  <div class="typography-button-font-weight">
-    <Row>
-      <p>These aren't the droids you're looking for... 🤖</p>
-    </Row>
-  </div>
-</Page>
+<p>These aren't the droids you're looking for... 🤖</p>

--- a/src/pages/_fallback.svelte
+++ b/src/pages/_fallback.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { notFound } from '../analytics'
+import { Row } from '../components'
+import { Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
 
 onMount(notFound)
@@ -9,6 +11,15 @@ onMount(notFound)
 p {
   text-align: center;
 }
+.typography-button-font-weight {
+  font-weight: var(--mdc-typography-button-font-weight);
+}
 </style>
 
-<p>These aren't the droids you're looking for... 🤖</p>
+<Page>
+  <div class="typography-button-font-weight">
+    <Row>
+      <p>These aren't the droids you're looking for... 🤖</p>
+    </Row>
+  </div>
+</Page>


### PR DESCRIPTION
### Added
- --mdc-typography-button-font-weight to _theme.scss
- .mdc-button rule to _theme.scss
### Changed
- _fallback.svelte content font-weight to use --mdc-typography-button-font-weight t
![Screenshot from 2021-09-30 16-19-04](https://user-images.githubusercontent.com/70765247/135524691-d0c7fbbb-14f9-4732-9c12-ec6a0dfd6b65.png)
o