### PR TITLE
Draft Claim view needs evidence

### DIFF
--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -89,6 +89,6 @@ export const determineMaxPayout = (
 
 export const isEvidenceNeeded = (claimItem: ClaimItem, claimStatus: ClaimStatus): boolean => {
   const willNeedEvidence = claimItem.fmv > 0 || claimItem.repair_estimate > 0
-  const canProvideEvidenceNow = ['Review1'].includes(claimStatus)
+  const canProvideEvidenceNow = ['Draft'].includes(claimStatus)
   return willNeedEvidence && canProvideEvidenceNow
 }

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -6,6 +6,8 @@ import { createEventDispatcher } from 'svelte'
 import Description from './Description.svelte'
 
 export let claim = {} as Claim
+export let noFilesUploaded: boolean
+export let needsFile: boolean
 
 const dispatch = createEventDispatcher()
 
@@ -63,7 +65,7 @@ const onDeny = () => dispatch('deny', message)
     <Button on:click={on('edit')} outlined>Edit claim</Button>
   {/if}
 
-  {#if status === 'Draft' || status === 'Receipt' || status === 'Revision'}
-    <Button raised on:click={on('submit')}>Submit claim</Button>
+  {#if ['Receipt', 'Revision'].includes(status) || (status === 'Draft' && needsFile)}
+    <Button raised disabled={noFilesUploaded} on:click={on('submit')}>Submit claim</Button>
   {/if}
 {/if}

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -95,6 +95,10 @@ $: !shouldAskReplaceOrFMV && unSetPayoutOption()
 $: !shouldAskIfRepairable && unSetRepairableSelection()
 $: !shouldAskForFMV && unSetFairMarketValue()
 $: !isRepairable && unSetRepairEstimate()
+$: needsEvidence = !unrepairableOrTooExpensive || payoutOption === PAYOUT_OPTION_FMV
+$: canContinueToEvidence =
+  (repairEstimateUSD > 0 && fairMarketValueUSD > 0) ||
+  (fairMarketValueUSD > 0 && !(repairableSelection === 'repairable'))
 
 // Calculate dynamic options for radio-button prompts.
 $: lossReasonOptions = $claimIncidentTypes.map(({ name }) => ({ label: name, value: name }))
@@ -264,8 +268,16 @@ const unSetReplaceEstimate = () => {
     {/if}
     <!--TODO: add evacuation amount when items is done (covered_value*(2/3))-->
     <p>
-      <Button on:click={onSaveForLater} outlined>Save For Later</Button>
-      <Button on:click={onSubmitClaim} raised>Submit Claim</Button>
+      {#if needsEvidence}
+        {#if canContinueToEvidence}
+          <Button on:click={onSaveForLater} raised>Continue</Button>
+        {:else}
+          <Button on:click={onSaveForLater} outlined>Save For Later</Button>
+        {/if}
+      {:else}
+        <Button on:click={onSaveForLater} outlined>Save For Later</Button>
+        <Button on:click={onSubmitClaim} raised>Submit Claim</Button>
+      {/if}
     </p>
   </Form>
 </div>

--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -52,7 +52,6 @@ export const claimStates: { [stateName: string]: State } = {
   Approved: { ...approved, title: 'Approved for payout' },
   DraftSecondary: warning,
   Review1: pendingClaim,
-  Review1Secondary: warning,
   Review2: pendingClaim,
   Review3: pendingClaim,
   Receipt2: warning,

--- a/src/pages/customer/claims/[claimId].svelte
+++ b/src/pages/customer/claims/[claimId].svelte
@@ -81,7 +81,6 @@ $: householdId = policy.household_id ? policy.household_id : ''
 
 $: incidentDate = formatDate(claim.incident_date)
 $: claimStatus = (claim.status || '') as ClaimStatus
-$: claimStatus === 'Draft' && $user.app_role === 'User' && editClaim()
 $: payoutOption = claimItem.payout_option as PayoutOption
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: needsReplaceReceipt = needsReceipt && payoutOption === 'Replacement'
@@ -248,6 +247,8 @@ function onDeleted(event: CustomEvent<string>) {
 
       <p>
         <ClaimActions
+          {noFilesUploaded}
+          {needsFile}
           {claim}
           on:ask-for-changes={onAskForChanges}
           on:deny={onDenyClaim}

--- a/src/pages/customer/claims/[claimId]/edit.svelte
+++ b/src/pages/customer/claims/[claimId]/edit.svelte
@@ -13,7 +13,7 @@ import {
   updateClaimItem,
 } from 'data/claims'
 import { itemsByPolicyId, loadItems, PolicyItem } from 'data/items'
-import { HOME, CUSTOMER_CLAIMS, customerClaim, customerClaimEdit } from 'helpers/routes'
+import { CUSTOMER_CLAIMS, customerClaim, customerClaimEdit } from 'helpers/routes'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
 
@@ -47,7 +47,7 @@ const updateClaimAndItem = async (event: CustomEvent): Promise<void> => {
 }
 const onSaveForLater = async (event: CustomEvent) => {
   await updateClaimAndItem(event)
-  $goto(HOME)
+  $goto(customerClaim(claimId))
 }
 const onSubmit = async (event: CustomEvent) => {
   await updateClaimAndItem(event)


### PR DESCRIPTION
- Stopped redirecting the customer to edit when status = Draft
- Show a continue button on claimForm when the customer will need to upload evidence unless fmv or repair estimate isn't filled, then show "safe for later".
- Allow submit after Evidence is uploaded
- send customer to claim view instead of home

![continueButton](https://user-images.githubusercontent.com/70765247/137158644-fe97d985-bb01-4bfd-84fc-7c6abf2f1cdc.gif)