### PR TITLE
added MakeAndModelModal

### DIFF
--- a/src/components/MakeAndModelModal.svelte
+++ b/src/components/MakeAndModelModal.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { Dialog } from '@silintl/ui-components'
+import { createEventDispatcher } from 'svelte'
+
+export let open = true
+
+let message = 'You may have difficulty getting coverage without a make and model.'
+let title = 'Missing information'
+
+const buttons: Dialog.AlertButton[] = [
+  { label: 'Go Back', action: 'cancel', class: 'mdc-button--raised' },
+  { label: 'Apply Anyway', action: 'submit', class: 'mdc-dialog__button' },
+]
+
+const dispatch = createEventDispatcher<{ closed: string }>()
+
+const handleDialog = (choice: string) => {
+  open = false
+  dispatch('closed', choice)
+}
+</script>
+
+<Dialog.Alert
+  {open}
+  {buttons}
+  defaultAction="cancel"
+  {title}
+  on:chosen={(e) => handleDialog(e.detail)}
+  on:closed={handleDialog}>{message}</Dialog.Alert
+>

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -2,6 +2,7 @@
 import user from '../../authn/user'
 import ConvertCurrencyLink from '../ConvertCurrencyLink.svelte'
 import Description from '../Description.svelte'
+import MakeAndModelModal from 'MakeAndModelModal.svelte'
 import MoneyInput from '../MoneyInput.svelte'
 import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import { AccountablePersonOptions, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
@@ -15,7 +16,10 @@ import { createEventDispatcher } from 'svelte'
 
 export let item = {} as PolicyItem
 export let policyId: any = undefined
+
+let formData = {} as any
 let open = false
+let makeModelIsOpen = false
 
 const dispatch = createEventDispatcher<{ submit: any; 'save-for-later': any; delete: any }>()
 
@@ -109,9 +113,13 @@ const validate = (formData: any) => {
 }
 
 const onSubmit = (event: Event) => {
-  const formData = getFormData()
+  formData = getFormData()
   validate(formData) //TODO open a scare dialog for make and model on certain categories
-  dispatch('submit', formData)
+  if (!(make && model) && $categories.find((category) => category.id === categoryId)?.require_make_model) {
+    makeModelIsOpen = true
+  } else {
+    dispatch('submit', formData)
+  }
 }
 
 const saveForLater = (event: Event) => {
@@ -131,6 +139,11 @@ const handleDialog = (event: CustomEvent<string>) => {
   if (event.detail === 'remove') {
     dispatch('delete')
   }
+}
+
+const onMakeModelClosed = (event: CustomEvent<string>) => {
+  makeModelIsOpen = false
+  event.detail === 'submit' && dispatch('submit', formData)
 }
 
 const setInitialValues = (item: PolicyItem) => {
@@ -205,5 +218,6 @@ const setInitialValues = (item: PolicyItem) => {
       <ItemDeleteModal {open} {item} on:closed={handleDialog} />
     {/if}
     <Button raised>Get approval</Button>
+    <MakeAndModelModal open={makeModelIsOpen} on:closed={onMakeModelClosed} />
   </p>
 </Form>

--- a/src/data/itemCategories.ts
+++ b/src/data/itemCategories.ts
@@ -6,6 +6,7 @@ export type ItemCategory = {
   help_text: string
   id: string
   name: string
+  require_make_model: boolean
   risk_category: any /*RiskCategory*/
   updated_at: string /*Date*/
 }


### PR DESCRIPTION
When itemCategory requires make and model for instant approval a modal now opens giving the user a chance to add them before submitting

![Screen Shot 2021-10-19 at 1 27 52 PM](https://user-images.githubusercontent.com/70765247/137961945-8230cb8a-b71e-40b1-9770-1e71ebb3a65a.png)
