### PR TITLE
Extract role-policy-selection to a store

### DIFF
--- a/src/components/AppDrawer.svelte
+++ b/src/components/AppDrawer.svelte
@@ -11,7 +11,6 @@ import { ROOT } from 'helpers/routes'
 export let menuItems: any[]
 export let myPolicies: Policy[]
 export let role: UserAppRole | undefined
-export let selectedPolicyId: string | undefined
 
 let toggle = false
 
@@ -32,7 +31,7 @@ const logoClickHandler = () => $goto(ROOT)
   <AppHeader on:toggleDrawer={() => (toggle = !toggle)} />
 
   <div class="role-and-policy-menu pt-1" slot="drawer-content-top">
-    <RoleAndPolicyMenu {myPolicies} {role} {selectedPolicyId} on:policy on:role />
+    <RoleAndPolicyMenu {myPolicies} {role} on:policy on:role />
   </div>
 
   <slot />

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -2,11 +2,11 @@
 import type { User, UserAppRole } from 'authn/user'
 import type { Policy } from 'data/policies.ts'
 import {
-  haveSetRolePolicy,
+  haveSetRolePolicySelection,
   RolePolicySelection,
   rolePolicySelection,
-  selectPolicy,
-  selectRole,
+  recordPolicySelection,
+  recordRoleSelection,
 } from 'data/role-policy-selection'
 import { POLICY_NEW_CORPORATE } from 'helpers/routes'
 import { Button, Menu, MenuItem } from '@silintl/ui-components'
@@ -34,7 +34,7 @@ let roleEntries: MenuItem[]
 $: myCorporatePolicies = myPolicies.filter(isCorporatePolicy)
 $: myHouseholdPolicies = myPolicies.filter(isHouseholdPolicy)
 
-$: $haveSetRolePolicy || tryToSetInitialRolePolicySelection(role, myCorporatePolicies, myHouseholdPolicies)
+$: $haveSetRolePolicySelection || tryToSetInitialRolePolicySelection(role, myCorporatePolicies, myHouseholdPolicies)
 
 $: buttonText = getButtonText($rolePolicySelection, myCorporatePolicies, myHouseholdPolicies)
 
@@ -44,9 +44,9 @@ $: householdPolicyEntries = getHouseholdEntries(myHouseholdPolicies)
 
 $: menuItems = [...roleEntries, ...corporatePolicyEntries, addCorporatePolicyEntry, ...householdPolicyEntries]
 
-const onPolicySelected = (policy: Policy) => {
-  selectPolicy(policy.id)
-  dispatch('policy', policy.id)
+const selectPolicy = (policyId: string) => {
+  recordPolicySelection(policyId)
+  dispatch('policy', policyId)
 }
 
 const getCorporatePolicyEntries = (policies: Policy[]): MenuItem[] => {
@@ -54,7 +54,7 @@ const getCorporatePolicyEntries = (policies: Policy[]): MenuItem[] => {
     return {
       icon: 'work',
       label: policy.account_detail,
-      action: () => onPolicySelected(policy),
+      action: () => selectPolicy(policy.id),
     }
   })
 }
@@ -64,25 +64,20 @@ const getHouseholdEntries = (policies: Policy[]): MenuItem[] => {
     return {
       icon: 'family_restroom',
       label: 'Household', // TODO: Replace with name, when available
-      action: () => onPolicySelected(policy),
+      action: () => selectPolicy(policy.id),
     }
   })
 }
 
-const selectSignator = () => {
-  selectRole('Signator')
-  dispatch('role', 'signator')
-}
-
-const selectSteward = () => {
-  selectRole('Steward')
-  dispatch('role', 'steward')
+const selectRole = (role: UserAppRole) => {
+  recordRoleSelection(role)
+  dispatch('role', role)
 }
 
 const getEntriesForRole = (role: UserAppRole | undefined): MenuItem[] => {
   const specialEntriesByRole = {
-    Signator: [{ icon: 'gavel', label: 'Signator', action: selectSignator }],
-    Steward: [{ icon: 'gavel', label: 'Steward', action: selectSteward }],
+    Signator: [{ icon: 'gavel', label: 'Signator', action: () => selectRole('Signator') }],
+    Steward: [{ icon: 'gavel', label: 'Steward', action: () => selectRole('Steward') }],
   }
   return specialEntriesByRole[role] || []
 }

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
-import type { UserAppRole } from 'authn/user'
+import type { User, UserAppRole } from 'authn/user'
 import type { Policy } from 'data/policies.ts'
-import { RolePolicySelection, rolePolicySelection, selectPolicy, selectRole } from 'data/role-policy-selection'
+import {
+  haveSetRolePolicy,
+  RolePolicySelection,
+  rolePolicySelection,
+  selectPolicy,
+  selectRole,
+} from 'data/role-policy-selection'
 import { POLICY_NEW_CORPORATE } from 'helpers/routes'
 import { Button, Menu, MenuItem } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
@@ -29,6 +35,8 @@ $: console.log($rolePolicySelection) // TEMP
 
 $: myCorporatePolicies = myPolicies.filter(isCorporatePolicy)
 $: myHouseholdPolicies = myPolicies.filter(isHouseholdPolicy)
+
+$: $haveSetRolePolicy || tryToSetInitialRolePolicySelection(role, myCorporatePolicies, myHouseholdPolicies)
 
 $: buttonText = getButtonText($rolePolicySelection, myCorporatePolicies, myHouseholdPolicies)
 
@@ -79,6 +87,35 @@ const getEntriesForRole = (role: UserAppRole | undefined): MenuItem[] => {
     Steward: [{ icon: 'gavel', label: 'Steward', action: selectSteward }],
   }
   return specialEntriesByRole[role] || []
+}
+
+const isAdminRole = (role: UserAppRole) => ['Signator', 'Steward'].includes(role)
+
+const tryToSetInitialRolePolicySelection = (
+  actualRole: UserAppRole,
+  corporatePolicies: Policy[],
+  householdPolicies: Policy[]
+) => {
+  console.log('tryToSetInitialRolePolicySelection', actualRole, corporatePolicies, householdPolicies) // TEMP
+
+  if (!actualRole) {
+    return
+  }
+
+  if (isAdminRole(actualRole)) {
+    selectRole(actualRole)
+    return
+  }
+
+  if (corporatePolicies.length > 0) {
+    selectPolicy(corporatePolicies[0].id)
+    return
+  }
+
+  if (householdPolicies.length > 0) {
+    selectPolicy(householdPolicies[0].id)
+    return
+  }
 }
 
 const getButtonText = (

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -89,23 +89,14 @@ const tryToSetInitialRolePolicySelection = (
   corporatePolicies: Policy[],
   householdPolicies: Policy[]
 ) => {
-  if (!actualRole) {
-    return
-  }
-
-  if (isAdminRole(actualRole)) {
-    recordRoleSelection(actualRole)
-    return
-  }
-
-  if (corporatePolicies.length > 0) {
-    recordPolicySelection(corporatePolicies[0].id)
-    return
-  }
-
-  if (householdPolicies.length > 0) {
-    recordPolicySelection(householdPolicies[0].id)
-    return
+  if (actualRole) {
+    if (isAdminRole(actualRole)) {
+      recordRoleSelection(actualRole)
+    } else if (corporatePolicies.length > 0) {
+      recordPolicySelection(corporatePolicies[0].id)
+    } else if (householdPolicies.length > 0) {
+      recordPolicySelection(householdPolicies[0].id)
+    }
   }
 }
 

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -31,8 +31,6 @@ let myCorporatePolicies: Policy[]
 let myHouseholdPolicies: Policy[]
 let roleEntries: MenuItem[]
 
-$: console.log($rolePolicySelection) // TEMP
-
 $: myCorporatePolicies = myPolicies.filter(isCorporatePolicy)
 $: myHouseholdPolicies = myPolicies.filter(isHouseholdPolicy)
 
@@ -96,8 +94,6 @@ const tryToSetInitialRolePolicySelection = (
   corporatePolicies: Policy[],
   householdPolicies: Policy[]
 ) => {
-  console.log('tryToSetInitialRolePolicySelection', actualRole, corporatePolicies, householdPolicies) // TEMP
-
   if (!actualRole) {
     return
   }

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { User, UserAppRole } from 'authn/user'
+import type { UserAppRole } from 'authn/user'
 import type { Policy } from 'data/policies.ts'
 import {
   haveSetRolePolicySelection,

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -88,7 +88,7 @@ const getButtonText = (
 ) => {
   const selectedPolicyId = rolePolicySelection.selectedPolicyId
   if (!selectedPolicyId) {
-    return rolePolicySelection.selectedRole
+    return rolePolicySelection.selectedRole || ''
   }
 
   const corporatePolicy = corporatePolicies.find((policy) => policy.id === selectedPolicyId)

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -8,7 +8,6 @@ import { createEventDispatcher } from 'svelte'
 
 export let myPolicies: Policy[]
 export let role: UserAppRole | undefined
-export let selectedPolicyId: string | undefined
 
 const addCorporatePolicyEntry: MenuItem = {
   icon: 'add',

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -94,17 +94,17 @@ const tryToSetInitialRolePolicySelection = (
   }
 
   if (isAdminRole(actualRole)) {
-    selectRole(actualRole)
+    recordRoleSelection(actualRole)
     return
   }
 
   if (corporatePolicies.length > 0) {
-    selectPolicy(corporatePolicies[0].id)
+    recordPolicySelection(corporatePolicies[0].id)
     return
   }
 
   if (householdPolicies.length > 0) {
-    selectPolicy(householdPolicies[0].id)
+    recordPolicySelection(householdPolicies[0].id)
     return
   }
 }

--- a/src/data/role-policy-selection.ts
+++ b/src/data/role-policy-selection.ts
@@ -2,13 +2,13 @@ import type { UserAppRole } from '../authn/user'
 import { writable } from 'svelte/store'
 
 export type RolePolicySelection = {
-  selectedRole: UserAppRole
+  selectedRole: UserAppRole | undefined
   selectedPolicyId: string | undefined
 }
 
 // TODO: Change this to a `readable` to avoid changes by any means other than our provided methods.
 export const rolePolicySelection = writable<RolePolicySelection>({
-  selectedRole: 'User', // TODO: Switch to 'Customer' when that change is made app-wide
+  selectedRole: undefined,
   selectedPolicyId: undefined,
 })
 

--- a/src/data/role-policy-selection.ts
+++ b/src/data/role-policy-selection.ts
@@ -12,25 +12,25 @@ export const rolePolicySelection = writable<RolePolicySelection>({
   selectedPolicyId: undefined,
 })
 
-export const haveSetRolePolicy = writable<boolean>(false)
+export const haveSetRolePolicySelection = writable<boolean>(false)
 
-const recordThatWeHaveSetRolePolicy = () => {
-  const haveAlreadySet = get(haveSetRolePolicy)
+const recordThatWeHaveSetRolePolicySelection = () => {
+  const haveAlreadySet = get(haveSetRolePolicySelection)
   if (!haveAlreadySet) {
-    haveSetRolePolicy.update(() => true)
+    haveSetRolePolicySelection.update(() => true)
   }
 }
 
-export const selectRole = (role: UserAppRole) => {
-  recordThatWeHaveSetRolePolicy()
+export const recordRoleSelection = (role: UserAppRole) => {
+  recordThatWeHaveSetRolePolicySelection()
   rolePolicySelection.update(() => ({
     selectedRole: role,
     selectedPolicyId: undefined,
   }))
 }
 
-export const selectPolicy = (policyId: string) => {
-  recordThatWeHaveSetRolePolicy()
+export const recordPolicySelection = (policyId: string) => {
+  recordThatWeHaveSetRolePolicySelection()
   rolePolicySelection.update(() => ({
     selectedRole: 'User',
     selectedPolicyId: policyId,

--- a/src/data/role-policy-selection.ts
+++ b/src/data/role-policy-selection.ts
@@ -1,5 +1,5 @@
 import type { UserAppRole } from '../authn/user'
-import { writable } from 'svelte/store'
+import { get, writable } from 'svelte/store'
 
 export type RolePolicySelection = {
   selectedRole: UserAppRole | undefined
@@ -12,7 +12,17 @@ export const rolePolicySelection = writable<RolePolicySelection>({
   selectedPolicyId: undefined,
 })
 
+export const haveSetRolePolicy = writable<boolean>(false)
+
+const recordThatWeHaveSetRolePolicy = () => {
+  const haveAlreadySet = get(haveSetRolePolicy)
+  if (!haveAlreadySet) {
+    haveSetRolePolicy.update(() => true)
+  }
+}
+
 export const selectRole = (role: UserAppRole) => {
+  recordThatWeHaveSetRolePolicy()
   rolePolicySelection.update(() => ({
     selectedRole: role,
     selectedPolicyId: undefined,
@@ -20,6 +30,7 @@ export const selectRole = (role: UserAppRole) => {
 }
 
 export const selectPolicy = (policyId: string) => {
+  recordThatWeHaveSetRolePolicy()
   rolePolicySelection.update(() => ({
     selectedRole: 'User',
     selectedPolicyId: policyId,

--- a/src/data/role-policy-selection.ts
+++ b/src/data/role-policy-selection.ts
@@ -17,22 +17,22 @@ export const haveSetRolePolicySelection = writable<boolean>(false)
 const recordThatWeHaveSetRolePolicySelection = () => {
   const haveAlreadySet = get(haveSetRolePolicySelection)
   if (!haveAlreadySet) {
-    haveSetRolePolicySelection.update(() => true)
+    haveSetRolePolicySelection.set(true)
   }
 }
 
 export const recordRoleSelection = (role: UserAppRole) => {
   recordThatWeHaveSetRolePolicySelection()
-  rolePolicySelection.update(() => ({
+  rolePolicySelection.set({
     selectedRole: role,
     selectedPolicyId: undefined,
-  }))
+  })
 }
 
 export const recordPolicySelection = (policyId: string) => {
   recordThatWeHaveSetRolePolicySelection()
-  rolePolicySelection.update(() => ({
+  rolePolicySelection.set({
     selectedRole: 'User',
     selectedPolicyId: policyId,
-  }))
+  })
 }

--- a/src/data/role-policy-selection.ts
+++ b/src/data/role-policy-selection.ts
@@ -1,0 +1,27 @@
+import type { UserAppRole } from '../authn/user'
+import { writable } from 'svelte/store'
+
+export type RolePolicySelection = {
+  selectedRole: UserAppRole
+  selectedPolicyId: string | undefined
+}
+
+// TODO: Change this to a `readable` to avoid changes by any means other than our provided methods.
+export const rolePolicySelection = writable<RolePolicySelection>({
+  selectedRole: 'User', // TODO: Switch to 'Customer' when that change is made app-wide
+  selectedPolicyId: undefined,
+})
+
+export const selectRole = (role: UserAppRole) => {
+  rolePolicySelection.update(() => ({
+    selectedRole: role,
+    selectedPolicyId: undefined,
+  }))
+}
+
+export const selectPolicy = (policyId: string) => {
+  rolePolicySelection.update(() => ({
+    selectedRole: 'User',
+    selectedPolicyId: policyId,
+  }))
+}

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -5,7 +5,7 @@ export const ROOT = '/'
 export const HOME = '/home'
 export const LOGOUT = '/logout'
 
-export const adminRoleHome = (role: AdminAppRole) => `/${role}/home`
+export const adminRoleHome = (role: AdminAppRole) => `/${role.toLowerCase()}/home`
 
 export const CHAT = '/chat'
 

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -3,13 +3,12 @@ import user, { isUserSteward } from '../authn/user'
 import { AppDrawer } from 'components'
 import { initialized as policiesInitialized, loadPolicies, Policy } from 'data/policies'
 import * as routes from 'helpers/routes'
-import { goto, params } from '@roxi/routify'
+import { goto } from '@roxi/routify'
 
 $: $policiesInitialized || loadPolicies()
 
 $: myPolicies = ($user.policies || []) as Policy[]
 $: myHouseholdPolicyId = $user.policy_id
-$: selectedPolicyId = $params.policyId
 
 // TODO: Update this based on the user's role and/or the RoleAndPolicyMenu selection.
 $: menuItems = [
@@ -58,13 +57,6 @@ const goToPolicyAsCustomer = (event: CustomEvent) => $goto(routes.policyHome(eve
 const goToRoleHome = (event: CustomEvent) => $goto(routes.adminRoleHome(event.detail))
 </script>
 
-<AppDrawer
-  {menuItems}
-  {myPolicies}
-  {selectedPolicyId}
-  role={$user.app_role}
-  on:policy={goToPolicyAsCustomer}
-  on:role={goToRoleHome}
->
+<AppDrawer {menuItems} {myPolicies} role={$user.app_role} on:policy={goToPolicyAsCustomer} on:role={goToRoleHome}>
   <slot />
 </AppDrawer>


### PR DESCRIPTION
### Added
- Add rolePolicySelection store

### Changed
- Refactor Role/Policy menu to record value in new store

### Fixed
- Fix adminRoleHome route (needed to be lowercase)

---

This doesn't quite get things working _correctly_, but it gets us closer.

Various facets of the challenge are...
- to properly initialize the Role/Policy menu (this mostly does so),
- to go to the appropriate page when the user manually changes the Roly/Policy menu's selection (this still does so),
- to properly handle situations where the user starts on a different policy's home page than their default Role/Policy menu selection (this doesn't do that yet), and
- to adjust the contents/destinations of the left nav menu based on the Role/Policy menu's selection (this doesn't do that yet, either).