### PR TITLE
Treat any policyId in the URL as authoritative

### DIFF
--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -3,10 +3,10 @@ import type { UserAppRole } from 'authn/user'
 import type { Policy } from 'data/policies.ts'
 import {
   haveSetRolePolicySelection,
-  RolePolicySelection,
-  rolePolicySelection,
   recordPolicySelection,
   recordRoleSelection,
+  RolePolicySelection,
+  rolePolicySelection,
 } from 'data/role-policy-selection'
 import { POLICY_NEW_CORPORATE } from 'helpers/routes'
 import { Button, Menu, MenuItem } from '@silintl/ui-components'

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -3,12 +3,14 @@ import type { UserAppRole } from 'authn/user'
 import type { Policy } from 'data/policies.ts'
 import {
   haveSetRolePolicySelection,
+  reactToUrlChanges,
   recordPolicySelection,
   recordRoleSelection,
   RolePolicySelection,
   rolePolicySelection,
 } from 'data/role-policy-selection'
 import { POLICY_NEW_CORPORATE } from 'helpers/routes'
+import { params } from '@roxi/routify'
 import { Button, Menu, MenuItem } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
@@ -30,6 +32,8 @@ let menuItems: MenuItem[]
 let myCorporatePolicies: Policy[]
 let myHouseholdPolicies: Policy[]
 let roleEntries: MenuItem[]
+
+$: reactToUrlChanges($params.policyId) // TEMP
 
 $: myCorporatePolicies = myPolicies.filter(isCorporatePolicy)
 $: myHouseholdPolicies = myPolicies.filter(isHouseholdPolicy)

--- a/src/data/role-policy-selection.ts
+++ b/src/data/role-policy-selection.ts
@@ -36,3 +36,12 @@ export const recordPolicySelection = (policyId: string) => {
     selectedPolicyId: policyId,
   })
 }
+
+const isAdminRole = (role: UserAppRole | undefined) => role && ['Signator', 'Steward'].includes(role)
+
+export const reactToUrlChanges = (urlPolicyId: string | undefined) => {
+  if (urlPolicyId) {
+    const { selectedRole } = get(rolePolicySelection)
+    isAdminRole(selectedRole) || recordPolicySelection(urlPolicyId)
+  }
+}

--- a/src/pages/customer/home.svelte
+++ b/src/pages/customer/home.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import user from '../../authn/user'
 import { policyHome } from 'helpers/routes'
-import { goto } from '@roxi/routify'
+import { redirect } from '@roxi/routify'
 
 /* TODO: Load customer's corporate policies (if any) and intelligently decide
  * which policy to default to. */
-$: $user.policy_id && $goto(policyHome($user.policy_id))
+$: $user.policy_id && $redirect(policyHome($user.policy_id))
 </script>

--- a/src/pages/policies/[policyId]/home.svelte
+++ b/src/pages/policies/[policyId]/home.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { items as itemsRoute } from 'helpers/routes'
-import { goto } from '@roxi/routify'
+import { redirect } from '@roxi/routify'
 
 export let policyId: string
 
-$: policyId && $goto(itemsRoute(policyId))
+$: policyId && $redirect(itemsRoute(policyId))
 </script>


### PR DESCRIPTION
### Changed
- Change our Role/Policy menu (and `$rolePolicySelection` store) to react to URL changes that include a `policyId` parameter _if_ the user is acting as a customer

### Fixed
- Fix some automatic redirects to avoid leaving browser history entries

---

This does not yet change the various places in the application that we use `$user.policy_id` to instead get it from the `$rolePolicySelection.selectedPolicyId`, but that's my next step.