### PR TITLE
Fix steward claim cards

### DIFF
--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -1,4 +1,5 @@
 import { CREATE, GET, UPDATE } from '.'
+import { UserAppRole } from '../authn/user'
 import { convertToCents } from 'helpers/money'
 import type { PolicyItem } from './items'
 import { derived, writable } from 'svelte/store'
@@ -368,6 +369,19 @@ export async function loadClaims(): Promise<void> {
 
   claims.set(response)
   initialized.set(true)
+}
+
+export async function getClaimsAwaitingAdmin(adminRole: UserAppRole): Promise<Claim[]> {
+  let desiredStatuses: ClaimStatus[] = []
+  if (adminRole === UserAppRole.Steward) {
+    desiredStatuses = statusesAwaitingSteward
+  } else if (adminRole === UserAppRole.Signator) {
+    desiredStatuses = statusesAwaitingSignator
+  }
+
+  const statusesForQueryString = desiredStatuses.map(encodeURIComponent).join(',')
+
+  return await GET<Claim[]>('claims/?status=' + statusesForQueryString)
 }
 
 export async function loadClaimsByPolicyId(policyId: string): Promise<void> {

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -136,8 +136,8 @@ export const selectedPolicyClaims = derived([claims, selectedPolicyId], ([claims
 })
 export const initialized = writable<boolean>(false)
 export const editableStatuses: ClaimStatus[] = ['Draft', 'Review1', 'Review2', 'Review3', 'Revision', 'Receipt']
-export const statusesAwaitingSteward: ClaimStatus[] = ['Review1', 'Review2', 'Review3b']
-export const statusesAwaitingSignator: ClaimStatus[] = ['Review2', 'Review3a']
+export const statusesAwaitingSteward: ClaimStatus[] = ['Review1', 'Review2', 'Review3', 'Review3b']
+export const statusesAwaitingSignator: ClaimStatus[] = ['Review2', 'Review3', 'Review3a']
 
 /**
  * Update a claim in our local list (store) of claims.

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -138,7 +138,7 @@ export const selectedPolicyClaims = derived([claims, selectedPolicyId], ([claims
 export const initialized = writable<boolean>(false)
 export const editableStatuses: ClaimStatus[] = ['Draft', 'Review1', 'Review2', 'Review3', 'Revision', 'Receipt']
 export const statusesAwaitingSteward: ClaimStatus[] = ['Review1', 'Review2', 'Review3', 'Review3b']
-export const statusesAwaitingSignator: ClaimStatus[] = ['Review2', 'Review3', 'Review3a']
+export const statusesAwaitingSignator: ClaimStatus[] = ['Review1', 'Review2', 'Review3', 'Review3a']
 
 /**
  * Update a claim in our local list (store) of claims.

--- a/src/pages/steward/home.svelte
+++ b/src/pages/steward/home.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
+import { UserAppRole } from '../../authn/user'
 import { ClaimCards, RecentActivityTable, Row } from 'components'
 import { loading } from 'components/progress'
 import { getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
-import {
-  Claim,
-  claims,
-  getClaimsAwaitingAdmin,
-  initialized as claimsInitialized,
-  getClaimsAwaitingAdmin,
-  statusesAwaitingSteward,
-} from 'data/claims'
+import { Claim, getClaimsAwaitingAdmin } from 'data/claims'
 import { dependentsByPolicyId, loadDependents } from 'data/dependents'
 import { allPolicyItems, itemsByPolicyId, loadItems } from 'data/items'
 import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
@@ -18,7 +12,6 @@ import { roleSelection } from 'data/role-policy-selection'
 import { customerClaimDetails } from 'helpers/routes'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
-import { UserAppRole } from '../../authn/user'
 
 let claimsAwaitingSteward: Claim[] = []
 


### PR DESCRIPTION
### Fixed
- Fix steward home page to show the appropriate claim cards
- Fix list of claims awaiting each admin role to include Review3

### Added
- Enable getting (from the API) the claims awaiting a specific admin role

---

There's a bug in the API causing an admin's call to "GET /claims" to not return anything, but it works if we specify which status claims we want. We already have a list of which claims are awaiting each admin role (steward, signator), so this simply makes use of that and may help when merging the steward and signator home pages.