### PR TITLE
Clean up claim cards

### DIFF
--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -13,11 +13,11 @@ import { differenceInSeconds, formatDistanceToNow } from 'date-fns'
 export let accountablePersons: AccountablePersonOptions[] = []
 export let claim: Claim = {} as Claim
 export let claimItem: ClaimItem = {} as ClaimItem
-export let item: PolicyItem = {} as PolicyItem
 export let isAdmin: boolean
 
 const dispatch = createEventDispatcher<{ 'goto-claim': Claim }>()
 
+$: item = claimItem.item || ({} as PolicyItem)
 $: wasUpdated = differenceInSeconds(Date.parse(claimItem.updated_at), Date.parse(claimItem.created_at)) > 1
 $: changedText = formatDistanceToNow(Date.parse(claimItem.updated_at), { addSuffix: true })
 $: state = getClaimState(claim.status, isAdmin) || ({} as State)

--- a/src/components/ClaimCards.svelte
+++ b/src/components/ClaimCards.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
 import type { AccountablePersonOptions } from 'data/accountablePersons'
 import type { Claim } from 'data/claims'
-import type { PolicyItem } from 'data/items'
 import ClaimCard from './ClaimCard.svelte'
 
 export let claims: Claim[]
-export let items: PolicyItem[]
 export let accountablePersons = [] as AccountablePersonOptions[]
 export let isAdmin: boolean
 </script>
@@ -21,14 +19,7 @@ export let isAdmin: boolean
   {#each claims as claim (claim.id)}
     {#each claim.claim_items || [] as claimItem (claimItem.id)}
       <div class="card">
-        <ClaimCard
-          {claim}
-          {claimItem}
-          {accountablePersons}
-          {isAdmin}
-          item={items.find((item) => item.id === claimItem.item_id) || {}}
-          on:goto-claim
-        />
+        <ClaimCard {claim} {claimItem} {accountablePersons} {isAdmin} on:goto-claim />
       </div>
     {/each}
   {/each}

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -46,6 +46,7 @@ export type ClaimItem = {
   fmv: number
   id: string
   is_repairable: boolean
+  item: PolicyItem
   item_id: string
   payout_amount: number
   payout_option: PayoutOption

--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -4,7 +4,7 @@ import { ClaimCards, Row, Breadcrumb } from 'components'
 import { AccountablePersonOptions, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
 import { dependentsByPolicyId, loadDependents } from 'data/dependents'
-import { loadItems, selectedPolicyItems } from 'data/items'
+import { loadItems } from 'data/items'
 import { selectedPolicy } from 'data/policies'
 import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import { roleSelection } from 'data/role-policy-selection'
@@ -27,8 +27,6 @@ $: adminBreadcrumbs = isAdmin
   : []
 
 $: breadcrumbLinks = [...adminBreadcrumbs, { name: 'Claims', url: customerClaims(policyId) }]
-
-$: items = $selectedPolicyItems
 
 $: dependents = $dependentsByPolicyId[policyId] || []
 $: dependentOptions = getDependentOptions(dependents)
@@ -56,7 +54,7 @@ const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(ev
 
   <Row cols={'12'}>
     {#if $selectedPolicyClaims.length}
-      <ClaimCards {accountablePersons} {isAdmin} claims={$selectedPolicyClaims} {items} on:goto-claim={onGotoClaim} />
+      <ClaimCards {accountablePersons} {isAdmin} claims={$selectedPolicyClaims} on:goto-claim={onGotoClaim} />
     {:else}
       No claims at this time.
     {/if}

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -47,7 +47,7 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
 <Page layout="grid">
   <Row cols={'12'}>
     <h3>{getNameOfPolicy($selectedPolicy)} Policy</h3>
-    <ClaimCards claims={$selectedPolicyClaims} {items} {accountablePersons} on:goto-claim={onGotoClaim} />
+    <ClaimCards claims={$selectedPolicyClaims} {accountablePersons} on:goto-claim={onGotoClaim} />
   </Row>
 
   <Row cols={'12'}>


### PR DESCRIPTION
### Fixed
- Refactor claim cards to use the item data provided with the claim data
- Update two uses of ClaimCards to stop passing in items 

I didn't update the admin home pages' uses because they'll be (re)moved in a forthcoming PR.