### PR TITLE
Add missing "Review3a" and "Review3b" statuses, where applicable

### DIFF
--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -28,6 +28,8 @@ $: switch (status) {
     actionLabel = action
     break
   case 'Review3':
+  case 'Review3a':
+  case 'Review3b':
     action = 'approve'
     actionLabel = 'give final approval'
     break
@@ -72,7 +74,7 @@ const onDeny = () => dispatch('deny', message)
 </style>
 
 {#if isAdmin}
-  {#if ['Review1', 'Review2', 'Review3'].includes(status)}
+  {#if ['Review1', 'Review2', 'Review3', 'Review3a', 'Review3b'].includes(status)}
     <div class="container">
       <div class="text-input">
         <TextField class="w-100" label="Send a message" bind:value={message} />
@@ -82,10 +84,10 @@ const onDeny = () => dispatch('deny', message)
         <Button on:click={onDeny} disabled={!message} outlined>deny</Button>
       </div>
       <div class="right-buttons">
-        {#if ['Review1', 'Review3'].includes(status)}
+        {#if ['Review1', 'Review3', 'Review3a', 'Review3b'].includes(status)}
           <Button on:click={onAskForChanges} disabled={!message} outlined>ask for changes</Button>
         {/if}
-        {#if ['Review2', 'Review3'].includes(status)}
+        {#if ['Review2', 'Review3', 'Review3a', 'Review3b'].includes(status)}
           <Button class="ml-1" on:click={onFixReceipt} disabled={!message} outlined>request a new receipt</Button>
         {/if}
       </div>

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -136,7 +136,16 @@ export const selectedPolicyClaims = derived([claims, selectedPolicyId], ([claims
   return claims.filter((c) => c.policy_id === selectedPolicyId)
 })
 export const initialized = writable<boolean>(false)
-export const editableStatuses: ClaimStatus[] = ['Draft', 'Review1', 'Review2', 'Review3', 'Revision', 'Receipt']
+export const editableStatuses: ClaimStatus[] = [
+  'Draft',
+  'Review1',
+  'Review2',
+  'Review3',
+  'Review3a',
+  'Review3b',
+  'Revision',
+  'Receipt',
+]
 export const statusesAwaitingSteward: ClaimStatus[] = ['Review1', 'Review2', 'Review3', 'Review3b']
 export const statusesAwaitingSignator: ClaimStatus[] = ['Review1', 'Review2', 'Review3', 'Review3a']
 
@@ -282,7 +291,8 @@ export const denyClaim = async (claimId: string, reason: string): Promise<void> 
 }
 
 /**
- * Admin reverts a claim to request a new/better receipt. Can be used at state "Review2" or "Review3".
+ * Admin reverts a claim to request a new/better receipt. Can be used at state
+ * "Review2" or "Review3"/"Review3a"/"Review3b".
  *
  * @export
  * @param {String} claimId

--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -63,6 +63,8 @@ export const claimStates: { [stateName: string]: State } = {
   Review1: pendingClaim,
   Review2: pendingClaim,
   Review3: pendingClaim,
+  Review3a: pendingClaim,
+  Review3b: pendingClaim,
   ReceiptSecondary: warning,
   Receipt: { ...approved, icon: 'done' },
   Paid: {
@@ -76,6 +78,8 @@ export const adminClaimStates: { [stateName: string]: State } = {
   Review1: needsReview,
   Review2: { ...needsReview, title: 'Needs receipt review' },
   Review3: { ...needsReview, title: 'Needs final claim review' },
+  Review3a: { ...needsReview, title: 'Needs final claim review' },
+  Review3b: { ...needsReview, title: 'Needs final claim review' },
   Revision: { ...pending, title: 'Awaiting changes' },
   Receipt: { ...pending, icon: 'check_circle', title: 'Approved' },
   ReceiptSecondary: { ...pending, title: 'Awaiting changes' },


### PR DESCRIPTION
### Fixed
- Add missing "Review3a" and "Review3b" statuses, where applicable

---

At the moment the backend is using "Review3", but the state diagram (and some discussion awhile back) indicates that it will be replaced with "Review3a" and "Review3b" statuses, to ensure that two different people sign off on payouts.

This PR just fills in the gaps so that we support all three options. Once the backend has been updated, we can remove the "Review3" status.