### PR TITLE
Don't show the "Add Item" button until we have a Policy ID

### DIFF
--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -52,7 +52,7 @@ $: menuItems = [
     icon: 'add_circle',
     label: 'Add Item',
     button: true,
-    hide: inAdminRole,
+    hide: inAdminRole || !policyId,
   },
 ]
 


### PR DESCRIPTION
### Fixed
- Don't show the "Add Item" button until we have a Policy ID

---

This prevents the user form going to the add-item page using a `null` Policy ID.