### PR TITLE
Feat/add policy items to cards grid

### DIFF
--- a/src/components/CardsGrid.svelte
+++ b/src/components/CardsGrid.svelte
@@ -3,7 +3,7 @@ import ClaimCard from './ClaimCard.svelte'
 import ItemCard from './ItemCard.svelte'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
 import { Claim, ClaimItem, incompleteClaimItemStatuses, isClaimItem } from 'data/claims'
-import { incompleteItemCoverageStatus, PolicyItem } from 'data/items'
+import { incompleteItemCoverageStatuses, PolicyItem } from 'data/items'
 import { isRecentClaim, RecentChange } from 'data/recent-activity'
 
 type CardItem = { data: ClaimItem | PolicyItem; claim?: Claim }
@@ -14,12 +14,12 @@ export let policyItems: PolicyItem[] = []
 export let accountablePersons: AccountablePersonOptions[] = []
 export let isAdmin: boolean = false
 
-$: items = recentChanges.length ? getRecentChanges(recentChanges) : mergeClaimsAndPolicyItems(claims, policyItems)
+$: items = recentChanges.length ? parseRecentChanges(recentChanges) : parseClaimsAndPolicyItems(claims, policyItems)
 
 const isIncomplete = (card: CardItem) => {
   return isClaimItem(card.data)
     ? incompleteClaimItemStatuses.includes(card.data.status)
-    : incompleteItemCoverageStatus.includes(card.data.coverage_status)
+    : incompleteItemCoverageStatuses.includes(card.data.coverage_status)
 }
 
 const isRecent = (card: CardItem) => {
@@ -34,7 +34,7 @@ const isRecentOrIncomplete = (card: CardItem) => isIncomplete(card) || isRecent(
 const sortByUpdateDate = (cardA: CardItem, cardB: CardItem) =>
   +new Date(cardB.data.updated_at) - +new Date(cardA.data.updated_at)
 
-const getRecentChanges = (changes: RecentChange[]): CardItem[] => {
+const parseRecentChanges = (changes: RecentChange[]): CardItem[] => {
   let cards: CardItem[] = []
   for (let change of changes) {
     if (isRecentClaim(change)) {
@@ -45,7 +45,8 @@ const getRecentChanges = (changes: RecentChange[]): CardItem[] => {
   }
   return cards
 }
-const mergeClaimsAndPolicyItems = (claims: Claim[], policyItems: PolicyItem[]): CardItem[] => {
+
+const parseClaimsAndPolicyItems = (claims: Claim[], policyItems: PolicyItem[]): CardItem[] => {
   // Add all the policy items and claim items together then filter and sort them
   let cards: CardItem[] = policyItems.map((item) => ({ data: item })) || []
   for (let claim of claims) {

--- a/src/components/CardsGrid.svelte
+++ b/src/components/CardsGrid.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import ClaimCard from './ClaimCard.svelte'
+import ItemCard from './ItemCard.svelte'
+import type { AccountablePersonOptions } from 'data/accountablePersons'
+import { Claim, ClaimItem, incompleteClaimItemStatuses, isClaimItem } from 'data/claims'
+import { incompleteItemCoverageStatus, PolicyItem } from 'data/items'
+import { isRecentClaim, RecentChange } from 'data/recent-activity'
+
+type CardItem = { data: ClaimItem | PolicyItem; claim?: Claim }
+
+export let recentChanges: RecentChange[] = []
+export let claims: Claim[] = []
+export let policyItems: PolicyItem[] = []
+export let accountablePersons: AccountablePersonOptions[] = []
+export let isAdmin: boolean = false
+
+$: items = recentChanges.length ? getRecentChanges(recentChanges) : mergeClaimsAndPolicyItems(claims, policyItems)
+
+const isIncomplete = (card: CardItem) => {
+  return isClaimItem(card.data)
+    ? incompleteClaimItemStatuses.includes(card.data.status)
+    : incompleteItemCoverageStatus.includes(card.data.coverage_status)
+}
+
+const isRecent = (card: CardItem) => {
+  const updatedAt = new Date(card.data.updated_at)
+  const today = new Date()
+  const aWeekAgo = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7)
+  return Number(updatedAt) > Number(aWeekAgo)
+}
+
+const isRecentOrIncomplete = (card: CardItem) => isIncomplete(card) || isRecent(card)
+
+const sortByUpdateDate = (cardA: CardItem, cardB: CardItem) =>
+  +new Date(cardB.data.updated_at) - +new Date(cardA.data.updated_at)
+
+const getRecentChanges = (changes: RecentChange[]): CardItem[] => {
+  let cards: CardItem[] = []
+  for (let change of changes) {
+    if (isRecentClaim(change)) {
+      cards.push({ data: change.Claim?.claim_items[0], claim: change.Claim })
+    } else {
+      cards.push({ data: change.Item })
+    }
+  }
+  return cards
+}
+const mergeClaimsAndPolicyItems = (claims: Claim[], policyItems: PolicyItem[]): CardItem[] => {
+  // Add all the policy items and claim items together then filter and sort them
+  let cards: CardItem[] = policyItems.map((item) => ({ data: item })) || []
+  for (let claim of claims) {
+    for (let claimItem of claim.claim_items) {
+      cards.push({ data: claimItem, claim })
+    }
+  }
+  return cards.filter(isRecentOrIncomplete).sort(sortByUpdateDate)
+}
+</script>
+
+<style>
+.card {
+  margin: 8px 8px 8px 0;
+  flex-basis: 330px;
+}
+</style>
+
+<div class="flex justify-start flex-wrap {$$props.class}">
+  {#each items as item (item.data.id)}
+    <div class="card">
+      {#if isClaimItem(item.data)}
+        <ClaimCard claim={item.claim} claimItem={item.data} {accountablePersons} {isAdmin} on:goto-claim />
+      {:else}
+        <ItemCard item={item.data} {accountablePersons} {isAdmin} on:goto-item />
+      {/if}
+    </div>
+  {/each}
+</div>

--- a/src/components/CardsGrid.svelte
+++ b/src/components/CardsGrid.svelte
@@ -14,7 +14,7 @@ export let policyItems: PolicyItem[] = []
 export let accountablePersons: AccountablePersonOptions[] = []
 export let isAdmin: boolean = false
 
-$: items = recentChanges.length ? parseRecentChanges(recentChanges) : parseClaimsAndPolicyItems(claims, policyItems)
+$: cardItems = recentChanges.length ? parseRecentChanges(recentChanges) : parseClaimsAndPolicyItems(claims, policyItems)
 
 const isIncomplete = (card: CardItem) => {
   return isClaimItem(card.data)
@@ -66,12 +66,12 @@ const parseClaimsAndPolicyItems = (claims: Claim[], policyItems: PolicyItem[]): 
 </style>
 
 <div class="flex justify-start flex-wrap {$$props.class}">
-  {#each items as item (item.data.id)}
+  {#each cardItems as cardItem (cardItem.data.id)}
     <div class="card">
-      {#if isClaimItem(item.data)}
-        <ClaimCard claim={item.claim} claimItem={item.data} {accountablePersons} {isAdmin} on:goto-claim />
+      {#if isClaimItem(cardItem.data)}
+        <ClaimCard claim={cardItem.claim} claimItem={cardItem.data} {accountablePersons} {isAdmin} on:goto-claim />
       {:else}
-        <ItemCard item={item.data} {accountablePersons} {isAdmin} on:goto-item />
+        <ItemCard item={cardItem.data} {accountablePersons} {isAdmin} on:goto-item />
       {/if}
     </div>
   {/each}

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+import ClaimCardBanner from './ClaimCardBanner.svelte'
+import type { AccountablePersonOptions } from 'data/accountablePersons'
+import type { PolicyItem } from 'data/items'
+import { getItemState, State } from 'data/states'
+import { Card, Button } from '@silintl/ui-components'
+import { createEventDispatcher } from 'svelte'
+import { differenceInSeconds, formatDistanceToNow } from 'date-fns'
+
+export let accountablePersons: AccountablePersonOptions[] = []
+export let item: PolicyItem = {} as PolicyItem
+export let isAdmin: boolean
+
+const dispatch = createEventDispatcher<{ 'goto-item': PolicyItem }>()
+
+$: wasUpdated = differenceInSeconds(Date.parse(item.updated_at), Date.parse(item.created_at)) > 1
+$: changedText = formatDistanceToNow(Date.parse(item.updated_at), { addSuffix: true })
+$: state = getItemState(item.coverage_status, isAdmin) || ({} as State)
+$: statusReason = item.status_reason || ''
+$: showRevisionMessage = statusReason && ['Revision', 'Receipt'].includes(item.coverage_status)
+$: accountablePerson = accountablePersons.find(
+  (person) => person.id === (item.accountable_user_id || item.accountable_dependent_id)
+)
+
+const gotoItem = () => dispatch('goto-item', item)
+</script>
+
+<style>
+.action {
+  margin: 16px;
+}
+
+.content {
+  overflow-wrap: anywhere;
+  padding-bottom: 0.5rem;
+}
+
+.multi-line-truncate {
+  /* See https://stackoverflow.com/a/13924997 and https://caniuse.com/#search=line-clamp for details. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2; /* number of lines to show */
+}
+
+.ml-50px {
+  margin-left: 50px;
+}
+</style>
+
+<Card noPadding class="h-300 py-0 {$$props.class}">
+  <ClaimCardBanner {statusReason} {state} {showRevisionMessage} />
+
+  <div class="mdc-typography--headline5 multi-line-truncate content ml-50px">
+    {item.name || ''}
+  </div>
+
+  <div class="content multi-line-truncate ml-50px">
+    {accountablePerson?.name || ''}
+  </div>
+
+  <div class="action pb-2 ml-50px" slot="actions">
+    <Button raised on:click={gotoItem}>View item</Button>
+
+    <div class="fs-12 gray mt-1">
+      {#if wasUpdated}
+        Last changed {changedText}
+      {:else}
+        No changes
+      {/if}
+    </div>
+  </div>
+</Card>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ import AppDrawer from './AppDrawer.svelte'
 import AppFooter from './AppFooter.svelte'
 import Banner from './Banner.svelte'
 import Breadcrumb from './Breadcrumb.svelte'
+import CardsGrid from './CardsGrid.svelte'
 import ClaimActions from './ClaimActions.svelte'
 import ClaimCard from './ClaimCard.svelte'
 import ClaimCards from './ClaimCards.svelte'
@@ -47,6 +48,7 @@ export {
   ItemsTable,
   MoneyInput,
   RadioOptions,
+  CardsGrid,
   ClaimCard,
   ClaimCards,
   RecentActivityTable,

--- a/src/components/progress/index.ts
+++ b/src/components/progress/index.ts
@@ -20,3 +20,4 @@ export const stop = (id: string): void => {
 }
 
 export const isLoadingById = (id: string): boolean => pending.includes(id)
+export const isLoadingPolicyItems = (policyId: string): boolean => pending.includes(`policies/${policyId}/items`)

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -148,8 +148,8 @@ export type DenyClaimRequestBody = {
 }
 
 export const claims = writable<Claim[]>([])
-export const selectedPolicyClaims = derived([claims, selectedPolicyId], ([claims, selectedPolicyId]) => {
-  return claims.filter((c) => c.policy_id === selectedPolicyId)
+export const selectedPolicyClaims = derived([claims, selectedPolicyId], ([$claims, $selectedPolicyId]) => {
+  return $claims.filter((c) => c.policy_id === $selectedPolicyId)
 })
 export const initialized = writable<boolean>(false)
 

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -71,6 +71,10 @@ export type ClaimItem = {
   updated_at: string /*Date*/
 }
 
+export function isClaimItem(item: any): item is ClaimItem {
+  return (item as ClaimItem).claim_id !== undefined
+}
+
 export type Claim = {
   claim_files: ClaimFile[]
   claim_items: ClaimItem[]

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -71,8 +71,8 @@ export type ClaimItem = {
   updated_at: string /*Date*/
 }
 
-export function isClaimItem(item: any): item is ClaimItem {
-  return (item as ClaimItem).claim_id !== undefined
+export function isClaimItem(obj: any): obj is ClaimItem {
+  return (obj as ClaimItem)?.claim_id !== undefined
 }
 
 export type Claim = {

--- a/src/data/dependents.ts
+++ b/src/data/dependents.ts
@@ -25,8 +25,8 @@ export type UpdatePolicyDependentRequestBody = {
 }
 
 export const dependentsByPolicyId = writable<{ [policyId: string]: PolicyDependent[] }>({})
-export const allPolicyDependents = derived(dependentsByPolicyId, (dependentsByPolicyId) => {
-  return Object.values(dependentsByPolicyId).flat()
+export const allPolicyDependents = derived(dependentsByPolicyId, ($dependentsByPolicyId) => {
+  return Object.values($dependentsByPolicyId).flat()
 })
 
 /**

--- a/src/data/dependents.ts
+++ b/src/data/dependents.ts
@@ -1,5 +1,5 @@
 import { CREATE, GET } from '.'
-import { writable } from 'svelte/store'
+import { derived, writable } from 'svelte/store'
 
 export type PolicyDependent = {
   child_birth_year?: number
@@ -25,6 +25,9 @@ export type UpdatePolicyDependentRequestBody = {
 }
 
 export const dependentsByPolicyId = writable<{ [policyId: string]: PolicyDependent[] }>({})
+export const allPolicyDependents = derived(dependentsByPolicyId, (dependentsByPolicyId) => {
+  return Object.values(dependentsByPolicyId).flat()
+})
 
 /**
  *

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -3,7 +3,19 @@ import { throwError } from '../error'
 import { derived, writable } from 'svelte/store'
 import { selectedPolicyId } from './role-policy-selection'
 
-export type ItemCoverageStatus = 'Draft' | 'Pending' | 'Approved' | 'Denied' | 'Revision' | 'Inactive'
+export enum ItemCoverageStatus {
+  Draft = 'Draft',
+  Pending = 'Pending',
+  Approved = 'Approved',
+  Denied = 'Denied',
+  Revision = 'Revision',
+  Inactive = 'Inactive',
+}
+export const incompleteItemCoverageStatus = [
+  ItemCoverageStatus.Draft,
+  ItemCoverageStatus.Pending,
+  ItemCoverageStatus.Revision,
+]
 
 export type RiskCategory = {
   created_at: string /*Date*/

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -11,7 +11,7 @@ export enum ItemCoverageStatus {
   Revision = 'Revision',
   Inactive = 'Inactive',
 }
-export const incompleteItemCoverageStatus = [
+export const incompleteItemCoverageStatuses = [
   ItemCoverageStatus.Draft,
   ItemCoverageStatus.Pending,
   ItemCoverageStatus.Revision,
@@ -86,13 +86,13 @@ export type UpdatePolicyItemRequestBody = {
 }
 
 export const itemsByPolicyId = writable<{ [policyId: string]: PolicyItem[] }>({})
-export const allPolicyItems = derived(itemsByPolicyId, (itemsByPolicyId) => {
-  return Object.values(itemsByPolicyId).flat()
+export const allPolicyItems = derived(itemsByPolicyId, ($itemsByPolicyId) => {
+  return Object.values($itemsByPolicyId).flat()
 })
 export const selectedPolicyItems = derived(
   [itemsByPolicyId, selectedPolicyId],
-  ([itemsByPolicyId, selectedPolicyId]) => {
-    return itemsByPolicyId[selectedPolicyId] || []
+  ([$itemsByPolicyId, $selectedPolicyId]) => {
+    return $itemsByPolicyId[$selectedPolicyId] || []
   }
 )
 

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -46,7 +46,7 @@ export type UpdatePolicyRequestBody = {
 
 export const policies = writable<Policy[]>([])
 export const selectedPolicy = derived([policies, selectedPolicyId], ([policies, selectedPolicyId]) => {
-  return policies.find((p) => p.id === selectedPolicyId) || {}
+  return policies.find((p) => p.id === selectedPolicyId) || ({} as Policy)
 })
 export const initialized = writable<boolean>(false)
 

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -45,8 +45,8 @@ export type UpdatePolicyRequestBody = {
 }
 
 export const policies = writable<Policy[]>([])
-export const selectedPolicy = derived([policies, selectedPolicyId], ([policies, selectedPolicyId]) => {
-  return policies.find((p) => p.id === selectedPolicyId) || ({} as Policy)
+export const selectedPolicy = derived([policies, selectedPolicyId], ([$policies, $selectedPolicyId]) => {
+  return $policies.find((p) => p.id === $selectedPolicyId) || ({} as Policy)
 })
 export const initialized = writable<boolean>(false)
 

--- a/src/data/policy-members.ts
+++ b/src/data/policy-members.ts
@@ -1,5 +1,5 @@
 import { GET } from './index'
-import { writable } from 'svelte/store'
+import { derived, writable } from 'svelte/store'
 
 export type PolicyMember = {
   email: string
@@ -12,6 +12,9 @@ export type PolicyMember = {
 }
 
 export const membersByPolicyId = writable<{ [policyId: string]: PolicyMember[] }>({})
+export const allPolicyMembers = derived(membersByPolicyId, (membersByPolicyId) => {
+  return Object.values(membersByPolicyId).flat()
+})
 
 /**
  * A function to fetch the items of a policy

--- a/src/data/policy-members.ts
+++ b/src/data/policy-members.ts
@@ -12,8 +12,8 @@ export type PolicyMember = {
 }
 
 export const membersByPolicyId = writable<{ [policyId: string]: PolicyMember[] }>({})
-export const allPolicyMembers = derived(membersByPolicyId, (membersByPolicyId) => {
-  return Object.values(membersByPolicyId).flat()
+export const allPolicyMembers = derived(membersByPolicyId, ($membersByPolicyId) => {
+  return Object.values($membersByPolicyId).flat()
 })
 
 /**

--- a/src/data/recent-activity.ts
+++ b/src/data/recent-activity.ts
@@ -26,12 +26,12 @@ export type RecentActivity = {
   Items: RecentItem[]
 }
 
-export const recentActivity = writable<RecentActivity>()
-export const recentChanges = derived(recentActivity, (recentActivity) => {
-  if (!recentActivity) return []
+const recentActivity = writable<RecentActivity>()
+export const recentChanges = derived(recentActivity, ($recentActivity) => {
+  if (!$recentActivity) return []
 
-  const recentClaims = recentActivity.Claims
-  const recentItems = recentActivity.Items
+  const recentClaims = $recentActivity.Claims
+  const recentItems = $recentActivity.Items
   const mergedRecentObjects = [...recentClaims, ...recentItems]
 
   mergedRecentObjects.sort((a: RecentChange, b: RecentChange) => {

--- a/src/data/recent-activity.ts
+++ b/src/data/recent-activity.ts
@@ -1,26 +1,47 @@
 import { GET } from '.'
 import type { Claim } from './claims'
 import type { PolicyItem } from './items'
-import { writable } from 'svelte/store'
+import { derived, writable } from 'svelte/store'
 
 export type RecentClaim = {
   Claim: Claim
   StatusUpdatedAt: string /* Date */
+}
+export function isRecentClaim(obj: any): obj is RecentClaim {
+  return !!((obj as RecentClaim)?.Claim && (obj as RecentClaim)?.StatusUpdatedAt)
 }
 
 export type RecentItem = {
   Item: PolicyItem
   StatusUpdatedAt: string /* Date */
 }
+export function isRecentItem(obj: any): obj is RecentItem {
+  return !!((obj as RecentItem)?.Item && (obj as RecentItem)?.StatusUpdatedAt)
+}
 
-type RecentChange = RecentClaim | RecentItem
+export type RecentChange = RecentClaim | RecentItem
 
 export type RecentActivity = {
   Claims: RecentClaim[]
   Items: RecentItem[]
 }
 
-export const recentChanges = writable<RecentChange[]>([])
+export const recentActivity = writable<RecentActivity>()
+export const recentChanges = derived(recentActivity, (recentActivity) => {
+  if (!recentActivity) return []
+
+  const recentClaims = recentActivity.Claims
+  const recentItems = recentActivity.Items
+  const mergedRecentObjects = [...recentClaims, ...recentItems]
+
+  mergedRecentObjects.sort((a: RecentChange, b: RecentChange) => {
+    const dateA = new Date(a.StatusUpdatedAt)
+    const dateB = new Date(b.StatusUpdatedAt)
+    return Number(dateB) - Number(dateA)
+  })
+
+  return mergedRecentObjects as RecentChange[]
+})
 
 /**
  * Load the list of recent activity.
@@ -29,14 +50,7 @@ export const recentChanges = writable<RecentChange[]>([])
  */
 export async function loadRecentActivity(): Promise<void> {
   const urlPath = 'steward/recent'
-  const recentActivity = await GET<RecentActivity>(urlPath)
-  const recentClaims = recentActivity.Claims
-  const recentItems = recentActivity.Items
-  const mergedRecentObjects = [...recentClaims, ...recentItems]
-  mergedRecentObjects.sort((a: RecentChange, b: RecentChange) => {
-    const dateA = new Date(a.StatusUpdatedAt)
-    const dateB = new Date(b.StatusUpdatedAt)
-    return Number(dateB) - Number(dateA)
-  })
-  recentChanges.set(mergedRecentObjects)
+  const result = await GET<RecentActivity>(urlPath)
+
+  recentActivity.set(result)
 }

--- a/src/pages/admin/home.svelte
+++ b/src/pages/admin/home.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-import { UserAppRole } from '../../authn/user'
-import { ClaimCards, RecentActivityTable, Row } from 'components'
+import type { UserAppRole } from '../../authn/user'
+import { CardsGrid, ClaimCards, RecentActivityTable, Row } from 'components'
 import { loading } from 'components/progress'
 import { getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
 import { Claim, getClaimsAwaitingAdmin } from 'data/claims'
-import { dependentsByPolicyId, loadDependents } from 'data/dependents'
-import { allPolicyItems, itemsByPolicyId, loadItems } from 'data/items'
-import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
+import { allPolicyDependents, dependentsByPolicyId, loadDependents } from 'data/dependents'
+import { allPolicyItems, itemsByPolicyId, loadItems, PolicyItem } from 'data/items'
+import { allPolicyMembers, loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import { loadRecentActivity, recentChanges } from 'data/recent-activity'
 import { roleSelection } from 'data/role-policy-selection'
-import { customerClaimDetails } from 'helpers/routes'
+import { customerClaimDetails, itemDetails } from 'helpers/routes'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
 
@@ -17,12 +17,12 @@ let actionableClaims: Claim[] = []
 
 loadRecentActivity()
 
-$: loadClaimsAwaitingAdmin($roleSelection)
+// $: loadClaimsAwaitingAdmin($roleSelection)
 $: actionableClaims.map((claim) => claim.policy_id).forEach(loadDataOnce)
 
-$: items = $allPolicyItems
-$: dependents = [].concat(...Object.values($dependentsByPolicyId))
-$: policyMembers = [].concat(...Object.values($membersByPolicyId))
+$: policyItems = $allPolicyItems
+$: dependents = $allPolicyDependents
+$: policyMembers = $allPolicyMembers
 
 $: dependentOptions = getDependentOptions(dependents)
 $: policyMemberOptions = getPolicyMemberOptions(policyMembers)
@@ -43,6 +43,7 @@ const loadDataOnce = (policyId: string) => {
   }
 }
 const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(event.detail.policy_id, event.detail.id))
+const onGotoPolicyItem = (event: CustomEvent<PolicyItem>) => $goto(itemDetails(event.detail.policy_id, event.detail.id))
 </script>
 
 <style>
@@ -50,7 +51,13 @@ const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(ev
 
 <Page layout="grid">
   <Row cols="12">
-    <ClaimCards isAdmin {accountablePersons} claims={actionableClaims} {items} on:goto-claim={onGotoClaim} />
+    <CardsGrid
+      isAdmin
+      {accountablePersons}
+      recentChanges={$recentChanges}
+      on:goto-claim={onGotoClaim}
+      on:goto-item={onGotoPolicyItem}
+    />
   </Row>
 
   <Row cols={'12'}>

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import { ClaimCards, ItemsTable, Row } from 'components'
-import { isLoadingById, loading } from 'components/progress'
+import { CardsGrid, ItemsTable, Row } from 'components'
+import { isLoadingPolicyItems, loading } from 'components/progress'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
 import { AccountablePersonOptions, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
 import { dependentsByPolicyId, loadDependents } from 'data/dependents'
-import { deleteItem, loadItems, selectedPolicyItems } from 'data/items'
+import { deleteItem, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
 import { getNameOfPolicy, selectedPolicy } from 'data/policies'
 import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import * as routes from 'helpers/routes'
@@ -15,8 +15,6 @@ import { Page } from '@silintl/ui-components'
 export let policyId: string
 
 $: policyId && loadItems(policyId)
-$: items = $selectedPolicyItems
-
 $: policyId && loadClaimsByPolicyId(policyId)
 
 $: policyId && loadDependents(policyId)
@@ -41,20 +39,35 @@ const onDelete = async (event: CustomEvent<any>) => {
 const onGotoClaim = (event: CustomEvent<Claim>) =>
   $goto(routes.customerClaimDetails(event.detail.policy_id, event.detail.id))
 
+const onGotoPolicyItem = (event: CustomEvent<PolicyItem>) =>
+  $goto(routes.itemDetails(event.detail.policy_id, event.detail.id))
+
 const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
 </script>
 
 <Page layout="grid">
   <Row cols={'12'}>
     <h3>{getNameOfPolicy($selectedPolicy)} Policy</h3>
-    <ClaimCards claims={$selectedPolicyClaims} {accountablePersons} on:goto-claim={onGotoClaim} />
+    <CardsGrid
+      {accountablePersons}
+      claims={$selectedPolicyClaims}
+      policyItems={$selectedPolicyItems}
+      on:goto-claim={onGotoClaim}
+      on:goto-item={onGotoPolicyItem}
+    />
   </Row>
 
   <Row cols={'12'}>
-    {#if $loading && isLoadingById(`policies/${policyId}/items`)}
+    {#if $loading && isLoadingPolicyItems(policyId)}
       Loading items...
     {:else}
-      <ItemsTable {items} {accountablePersons} {policyId} on:delete={onDelete} on:gotoItem={onGotoItem} />
+      <ItemsTable
+        items={$selectedPolicyItems}
+        {accountablePersons}
+        {policyId}
+        on:delete={onDelete}
+        on:gotoItem={onGotoItem}
+      />
     {/if}
   </Row>
 </Page>


### PR DESCRIPTION
* Create a CardsGrid component that includes data for both claims and policy items
* Populate with data from recent activity endpoint

This PR introduced the TypeScript concept of [type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) (or type guards). This is quite useful when working with arrays of data that could contain multiple types (such as the store we use for recent activity)