### PR TITLE
Handle item-less policy display better

### DIFF
--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -58,9 +58,7 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
   </Row>
 
   <Row cols={'12'}>
-    {#if $loading && isLoadingPolicyItems(policyId)}
-      Loading items...
-    {:else}
+    {#if $selectedPolicyItems.length > 0}
       <ItemsTable
         items={$selectedPolicyItems}
         {accountablePersons}
@@ -68,6 +66,8 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
         on:delete={onDelete}
         on:gotoItem={onGotoItem}
       />
-    {/if}
+    {:else if $loading && isLoadingPolicyItems(policyId)}
+      Loading items...
+    {:else}{/if}
   </Row>
 </Page>

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -7,12 +7,15 @@ import { dependentsByPolicyId, loadDependents } from 'data/dependents'
 import { deleteItem, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
 import { getNameOfPolicy, selectedPolicy } from 'data/policies'
 import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
+import { selectedPolicyId } from 'data/role-policy-selection'
 import * as routes from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
-import { Page } from '@silintl/ui-components'
+import { Button, Page } from '@silintl/ui-components'
 
-export let policyId: string
+let policyId: string
+
+$: policyId = $selectedPolicyId
 
 $: policyId && loadItems(policyId)
 $: policyId && loadClaimsByPolicyId(policyId)

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -68,6 +68,11 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
       />
     {:else if $loading && isLoadingPolicyItems(policyId)}
       Loading items...
-    {:else}{/if}
+    {:else}
+      <p class="text-align-center">You don't have any items in this policy</p>
+      <p class="text-align-center">
+        <Button class="m-1" raised prependIcon="add_circle" url={routes.itemsNew(policyId)}>Add Item</Button>
+      </p>
+    {/if}
   </Row>
 </Page>


### PR DESCRIPTION
### Added
- Show friendlier text and an "Add Item" button for itemless policies

### Fixed
- If we already have items, show them even while reloading the items data
- Update policy items page to use `$selectedPolicyId` store