### PR TITLE
Fix policy-name code

### DIFF
--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -112,12 +112,16 @@ export function clear(): void {
 
 export const getNameOfPolicy = (policy: Policy): string => {
   let policyName = ''
-  if (policy?.type === 'Team') {
-    policyName = policy?.name || 'Team'
-  } else if (policy?.type === 'Household') {
-    const members = policy?.members || []
-    const lastName = members[0]?.last_name || ''
-    policyName = lastName + ' Household'
+  if (policy?.name) {
+    policyName = policy.name
+  } else {
+    if (policy?.type === 'Team') {
+      policyName = 'Team'
+    } else if (policy?.type === 'Household') {
+      const members = policy?.members || []
+      const lastName = members[0]?.last_name || ''
+      policyName = lastName + ' Household'
+    }
   }
   return policyName.trim()
 }

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -31,7 +31,7 @@ $: accountablePersons = [...policyMemberOptions, ...dependentOptions]
 $: policyId && loadItems(policyId)
 $: items = $selectedPolicyItems
 $: claims = policy.claims || []
-$: policyName = policy.type === 'Team' ? policy.account_detail : policy.household_id
+$: policyName = getNameOfPolicy(policy)
 $: policyName && (metatags.title = formatPageTitle(`Policies > ${policyName}`))
 </script>
 

--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -5,7 +5,7 @@ import { AccountablePersonOptions, getDependentOptions, getPolicyMemberOptions }
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
 import { dependentsByPolicyId, loadDependents } from 'data/dependents'
 import { loadItems } from 'data/items'
-import { selectedPolicy } from 'data/policies'
+import { getNameOfPolicy, selectedPolicy } from 'data/policies'
 import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import { roleSelection } from 'data/role-policy-selection'
 import { customerClaims, customerClaimDetails, POLICIES, policyDetails } from 'helpers/routes'
@@ -17,7 +17,7 @@ import { onMount } from 'svelte'
 export let policyId: string
 $: policy = $selectedPolicy
 
-$: policyName = policy.type === 'Team' ? policy.account_detail : policy.household_id
+$: policyName = getNameOfPolicy(policy)
 $: isAdmin = $roleSelection !== UserAppRole.Customer
 $: adminBreadcrumbs = isAdmin
   ? [

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -42,7 +42,7 @@ import {
 } from 'data/claims'
 import { dependentsByPolicyId, loadDependents } from 'data/dependents'
 import { loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
-import { getPolicyById, loadPolicy, memberBelongsToPolicy, policies, Policy } from 'data/policies'
+import { getNameOfPolicy, getPolicyById, loadPolicy, memberBelongsToPolicy, policies, Policy } from 'data/policies'
 import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import { roleSelection, selectedPolicyId } from 'data/role-policy-selection'
 import { formatMoney } from 'helpers/money'
@@ -121,7 +121,7 @@ $: maximumPayout = determineMaxPayout(payoutOption, claimItem, item.coverage_amo
 
 // Dynamic breadcrumbs data:
 $: item.name && claim.reference_number && (claimName = `${item.name} (${claim.reference_number})`)
-$: policyName = policy.type === 'Team' ? policy.account_detail : policy.household_id
+$: policyName = getNameOfPolicy(policy)
 $: isAdmin = $roleSelection !== UserAppRole.Customer
 $: adminBreadcrumbs = isAdmin
   ? [

--- a/src/pages/policies/[policyId]/items/[itemId].svelte
+++ b/src/pages/policies/[policyId]/items/[itemId].svelte
@@ -14,7 +14,7 @@ import {
   reviseItem,
   selectedPolicyItems,
 } from 'data/items'
-import { loadPolicy, memberBelongsToPolicy, policies, Policy } from 'data/policies'
+import { getNameOfPolicy, loadPolicy, memberBelongsToPolicy, policies, Policy } from 'data/policies'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { loadPolicyItemHistory, policyHistoryByItemId } from 'data/policy-history'
 import { items as itemsRoute, itemDetails, itemEdit, itemNewClaim, POLICIES, policyDetails } from 'helpers/routes'
@@ -60,7 +60,7 @@ $: allowRemoveCovereage = (!['Inactive', 'Denied'].includes(status) && isMemberO
 $: canEdit = ['Draft', 'Pending', 'Revision'].includes(status) && isMemberOfPolicy
 
 // Dynamic breadcrumbs data:
-$: policyName = policy.type === 'Team' ? policy.account_detail : policy.household_id
+$: policyName = getNameOfPolicy(policy)
 $: adminBreadcrumbs = isAdmin
   ? [
       { name: 'Policies', url: POLICIES },


### PR DESCRIPTION
### Changed
- Only calculate a policy name client-side if none was provided by the API

### Fixed
- Update UI code to be consistent about how it obtains a policy's name