### PR TITLE
remove exception from breadcrumbs component

### DIFF
--- a/src/components/Breadcrumb.svelte
+++ b/src/components/Breadcrumb.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { throwError } from '../error'
 import { HOME } from 'helpers/routes'
 import { goto, url } from '@roxi/routify'
 
@@ -25,9 +24,7 @@ $: if (links.length === 0) {
 } else {
   urls = []
   links.forEach((val) => {
-    if (!val.url || !val.name) {
-      throwError('Error: no url or name field for provided links array')
-    } else {
+    if (val.url && val.name) {
       urls = [...urls, { url: val.url, name: val.name }]
     }
   })


### PR DESCRIPTION
in some cases where we are dynamically constructing the breadcrumbs, not all values are on pageload (eg the policy household name). when we pass an empty node to the breadcrumbs component (even for a second) it will result in an exception being thrown and the entire page blowing up! kapow! this seems like a less than ideal situation. it might be better to just ignore invalid breadcrumb nodes until the reactive statement re-triggers and we have a value.