### PR TITLE
remove accountablePersons from most components

### DIFF
--- a/src/components/CardsGrid.svelte
+++ b/src/components/CardsGrid.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import ClaimCard from './ClaimCard.svelte'
 import ItemCard from './ItemCard.svelte'
-import type { AccountablePersonOptions } from 'data/accountablePersons'
 import { Claim, ClaimItem, incompleteClaimItemStatuses, isClaimItem } from 'data/claims'
 import { incompleteItemCoverageStatuses, PolicyItem } from 'data/items'
 import { isRecentClaim, RecentChange } from 'data/recent-activity'
@@ -11,7 +10,6 @@ type CardItem = { data: ClaimItem | PolicyItem; claim?: Claim }
 export let recentChanges: RecentChange[] = []
 export let claims: Claim[] = []
 export let policyItems: PolicyItem[] = []
-export let accountablePersons: AccountablePersonOptions[] = []
 export let isAdmin: boolean = false
 
 $: cardItems = recentChanges.length ? parseRecentChanges(recentChanges) : parseClaimsAndPolicyItems(claims, policyItems)
@@ -69,9 +67,9 @@ const parseClaimsAndPolicyItems = (claims: Claim[], policyItems: PolicyItem[]): 
   {#each cardItems as cardItem (cardItem.data.id)}
     <div class="card">
       {#if isClaimItem(cardItem.data)}
-        <ClaimCard claim={cardItem.claim} claimItem={cardItem.data} {accountablePersons} {isAdmin} on:goto-claim />
+        <ClaimCard claim={cardItem.claim} claimItem={cardItem.data} {isAdmin} on:goto-claim />
       {:else}
-        <ItemCard item={cardItem.data} {accountablePersons} {isAdmin} on:goto-item />
+        <ItemCard item={cardItem.data} {isAdmin} on:goto-item />
       {/if}
     </div>
   {/each}

--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -2,7 +2,6 @@
 import { getUploadLabel, isEvidenceNeeded } from '../business-rules/claim-payout-amount'
 import ClaimBanner from './banners/ClaimBanner.svelte'
 import ClaimCardBanner from './ClaimCardBanner.svelte'
-import type { AccountablePersonOptions } from 'data/accountablePersons'
 import type { Claim, ClaimItem } from 'data/claims'
 import type { PolicyItem } from 'data/items'
 import { getClaimState, State } from 'data/states'
@@ -10,7 +9,6 @@ import { Card, Button } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 import { differenceInSeconds, formatDistanceToNow } from 'date-fns'
 
-export let accountablePersons: AccountablePersonOptions[] = []
 export let claim: Claim = {} as Claim
 export let claimItem: ClaimItem = {} as ClaimItem
 export let isAdmin: boolean
@@ -23,9 +21,6 @@ $: changedText = formatDistanceToNow(Date.parse(claimItem.updated_at), { addSuff
 $: state = getClaimState(claim.status, isAdmin) || ({} as State)
 $: statusReason = claim.status_reason || ('' as string)
 $: showRevisionMessage = (statusReason && ['Revision', 'Receipt'].includes(claim.status)) as boolean
-$: accountablePerson = accountablePersons.find(
-  (person) => person.id === (item.accountable_user_id || item.accountable_dependent_id)
-)
 $: payoutOption = claimItem.payout_option
 $: needsRepairReceipt = needsReceipt && payoutOption === 'Repair'
 $: receiptType = needsRepairReceipt ? 'repair' : 'replacement'
@@ -79,7 +74,7 @@ const gotoClaim = () => dispatch('goto-claim', claim)
   </div>
 
   <div class="content multi-line-truncate ml-50px">
-    {accountablePerson?.name || ''}
+    {item.accountable_person?.name || ''}
   </div>
 
   <div class="action pb-2 ml-50px" slot="actions">

--- a/src/components/ClaimCards.svelte
+++ b/src/components/ClaimCards.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 import ClaimCard from './ClaimCard.svelte'
-import type { AccountablePersonOptions } from 'data/accountablePersons'
 import { Claim, ClaimItem, incompleteClaimItemStatuses } from '../data/claims'
 
 export let claims: Claim[]
-export let accountablePersons = [] as AccountablePersonOptions[]
 export let isAdmin: boolean
 
 const isIncomplete = (claimItem: ClaimItem) => incompleteClaimItemStatuses.includes(claimItem.status)
@@ -35,7 +33,7 @@ const getRecentOrIncompleteClaimItems = (claim: Claim): ClaimItem[] => {
   {#each claims as claim (claim.id)}
     {#each getRecentOrIncompleteClaimItems(claim) as claimItem (claimItem.id)}
       <div class="card">
-        <ClaimCard {claim} {claimItem} {accountablePersons} {isAdmin} on:goto-claim />
+        <ClaimCard {claim} {claimItem} {isAdmin} on:goto-claim />
       </div>
     {/each}
   {/each}

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
 import ClaimCardBanner from './ClaimCardBanner.svelte'
-import type { AccountablePersonOptions } from 'data/accountablePersons'
 import type { PolicyItem } from 'data/items'
 import { getItemState, State } from 'data/states'
 import { Card, Button } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 import { differenceInSeconds, formatDistanceToNow } from 'date-fns'
 
-export let accountablePersons: AccountablePersonOptions[] = []
 export let item: PolicyItem = {} as PolicyItem
 export let isAdmin: boolean
 
@@ -18,9 +16,6 @@ $: changedText = formatDistanceToNow(Date.parse(item.updated_at), { addSuffix: t
 $: state = getItemState(item.coverage_status, isAdmin) || ({} as State)
 $: statusReason = item.status_reason || ''
 $: showRevisionMessage = statusReason && ['Revision', 'Receipt'].includes(item.coverage_status)
-$: accountablePerson = accountablePersons.find(
-  (person) => person.id === (item.accountable_user_id || item.accountable_dependent_id)
-)
 
 const gotoItem = () => dispatch('goto-item', item)
 </script>
@@ -57,7 +52,7 @@ const gotoItem = () => dispatch('goto-item', item)
   </div>
 
   <div class="content multi-line-truncate ml-50px">
-    {accountablePerson?.name || ''}
+    {item.accountable_person?.name || ''}
   </div>
 
   <div class="action pb-2 ml-50px" slot="actions">

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -2,28 +2,19 @@
 import Banner from './Banner.svelte'
 import ItemBanner from './banners/ItemBanner.svelte'
 import MessageBanner from './banners/MessageBanner.svelte'
-import {
-  AccountablePersonOptions,
-  getAccountablePerson,
-  getDependentOptions,
-  getPolicyMemberOptions,
-} from 'data/accountablePersons'
-import { dependentsByPolicyId } from 'data/dependents'
 import type { PolicyItem, ItemCoverageStatus } from 'data/items'
 import { getPolicyById, loadPolicy, policies, Policy } from 'data/policies'
-import { membersByPolicyId } from 'data/policy-members'
 import { formatMoney } from 'helpers/money'
 import { formatDate } from './dates'
 import { formatDistanceToNow } from 'date-fns'
 import { onMount } from 'svelte'
 
 export let item: PolicyItem
-export let isCheckingOut: boolean
+export let isCheckingOut: boolean = false
 export let policyId: string
 export let isAdmin: boolean
 
 let policy: Policy
-let accountablePersons: AccountablePersonOptions[]
 
 onMount(() => loadPolicy(policyId))
 
@@ -34,15 +25,6 @@ $: statusText = getItemStatusText(item)
 $: status = (item.coverage_status || '') as ItemCoverageStatus
 $: showRevisionMessage = item.status_reason && status === 'Revision'
 $: startDate = formatDate(item.coverage_start_date)
-
-$: dependents = $dependentsByPolicyId[policyId] || []
-$: dependentOptions = getDependentOptions(dependents)
-
-$: policyMembers = $membersByPolicyId[policyId] || []
-$: policyMemberOptions = getPolicyMemberOptions(policyMembers)
-
-$: accountablePersons = [...policyMemberOptions, ...dependentOptions]
-$: accountablePersonName = getAccountablePerson(item, accountablePersons)?.name
 
 const getItemStatusText = (item: PolicyItem) => {
   const updatedAtStr = item.updated_at ? formatDistanceToNow(Date.parse(item.updated_at), { addSuffix: true }) : ''
@@ -67,7 +49,7 @@ const getItemStatusText = (item: PolicyItem) => {
     <b>Annual premium</b>
     <div class="my-2px">{formatMoney(item.annual_premium)}</div>
     <br />
-    <b>{accountablePersonName || ''}</b>
+    <b>{item.accountable_person?.name || ''}</b>
     <div class="mt-4px">Household ID</div>
     <div>{householdId}</div>
   </div>

--- a/src/components/ItemsTable.svelte
+++ b/src/components/ItemsTable.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import ItemDeleteModal from './ItemDeleteModal.svelte'
 import { formatDate } from 'components/dates'
-import { AccountablePersonOptions, getAccountablePerson } from 'data/accountablePersons'
 import type { PolicyItem } from 'data/items'
 import { formatMoney } from 'helpers/money'
 import { itemDetails, itemEdit } from 'helpers/routes'
@@ -9,7 +8,6 @@ import { createEventDispatcher } from 'svelte'
 import { Datatable, Menu, MenuItem } from '@silintl/ui-components'
 
 export let items = [] as PolicyItem[]
-export let accountablePersons = [] as AccountablePersonOptions[]
 export let policyId: string
 
 let currentItem = {} as PolicyItem
@@ -113,7 +111,7 @@ const getStatusClass = (status: string) => (status === 'Draft' ? 'mdc-theme--pri
         <Datatable.Data.Row.Item class={getStatusClass(item.coverage_status)}
           >{item.coverage_status || ''}</Datatable.Data.Row.Item
         >
-        <Datatable.Data.Row.Item>{getAccountablePerson(item, accountablePersons).name || ''}</Datatable.Data.Row.Item>
+        <Datatable.Data.Row.Item>{item.accountable_person?.name || ''}</Datatable.Data.Row.Item>
         <Datatable.Data.Row.Item>{formatMoney(item.coverage_amount)}</Datatable.Data.Row.Item>
         <Datatable.Data.Row.Item>{formatMoney(item.annual_premium)}</Datatable.Data.Row.Item>
         <Datatable.Data.Row.Item>{formatDate(item.updated_at)}</Datatable.Data.Row.Item>

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -6,16 +6,16 @@ import MakeAndModelModal from 'MakeAndModelModal.svelte'
 import MoneyInput from '../MoneyInput.svelte'
 import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import { AccountablePersonOptions, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
-import { dependentsByPolicyId } from 'data/dependents'
+import { selectedPolicyDependents } from 'data/dependents'
 import type { ItemCoverageStatus, PolicyItem } from 'data/items'
 import { categories, loadCategories, initialized as catItemsInitialized } from 'data/itemCategories'
-import { membersByPolicyId } from 'data/policy-members'
+import { selectedPolicyMembers } from 'data/policy-members'
 import { assertHas } from '../../validation/assertions'
 import { Button, Form, Select, TextArea, TextField } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
 export let item = {} as PolicyItem
-export let policyId: any = undefined
+export let policyId: string
 
 let formData = {} as any
 let open = false
@@ -41,16 +41,13 @@ let uniqueIdentifier: string = ''
 // Set initial values based on the provided item data.
 $: setInitialValues(item)
 
-let accountablePersons = [] as AccountablePersonOptions[]
-let initialAccountablePersonId: any = undefined
-let initialCategoryId: any = undefined
+let accountablePersons: AccountablePersonOptions[] = []
+let initialAccountablePersonId: string
+let initialCategoryId: string
 let today = new Date()
 
-$: dependents = $dependentsByPolicyId[policyId] || []
-$: dependentOptions = getDependentOptions(dependents)
-
-$: policyMembers = $membersByPolicyId[policyId] || []
-$: policyMemberOptions = getPolicyMemberOptions(policyMembers)
+$: dependentOptions = getDependentOptions($selectedPolicyDependents)
+$: policyMemberOptions = getPolicyMemberOptions($selectedPolicyMembers)
 
 $: accountablePersons = [...policyMemberOptions, ...dependentOptions]
 $: accountablePerson = accountablePersons.find(
@@ -87,7 +84,7 @@ const getFormData = () => {
 }
 
 const onAccountablePersonSelectPopulated = () => {
-  initialAccountablePersonId = item.accountable_user_id || item.accountable_dependent_id || $user.id
+  initialAccountablePersonId = item.accountable_person?.id || $user.id
 }
 
 const onCategorySelectPopulated = () => {

--- a/src/data/accountablePersons.ts
+++ b/src/data/accountablePersons.ts
@@ -1,5 +1,3 @@
-import type { PolicyItem } from './items'
-
 export type AccountablePersonOptions = {
   id: string
   name: string
@@ -20,9 +18,4 @@ export const getDependentOptions = (dependents: any[]): AccountablePersonOptions
     name: dependent.name,
     country: dependent.country,
   }))
-}
-
-export const getAccountablePerson = (item: PolicyItem, persons: any): AccountablePersonOptions => {
-  const id: any = item.accountable_user_id || item.accountable_dependent_id
-  return persons?.find((person: any) => person.id === id) || {}
 }

--- a/src/data/dependents.ts
+++ b/src/data/dependents.ts
@@ -1,5 +1,6 @@
 import { CREATE, DELETE, GET, UPDATE } from '.'
 import { derived, writable } from 'svelte/store'
+import { selectedPolicyId } from './role-policy-selection'
 
 export type PolicyDependent = {
   child_birth_year?: number
@@ -24,6 +25,12 @@ export type UpdatePolicyDependentRequestBody = {
 }
 
 export const dependentsByPolicyId = writable<{ [policyId: string]: PolicyDependent[] }>({})
+export const selectedPolicyDependents = derived(
+  [dependentsByPolicyId, selectedPolicyId],
+  ([$dependentsByPolicyId, $selectedPolicyId]) => {
+    return $dependentsByPolicyId[$selectedPolicyId] || []
+  }
+)
 export const allPolicyDependents = derived(dependentsByPolicyId, ($dependentsByPolicyId) => {
   return Object.values($dependentsByPolicyId).flat()
 })

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -17,6 +17,10 @@ export const incompleteItemCoverageStatuses = [
   ItemCoverageStatus.Revision,
 ]
 
+export type AccountablePerson = {
+  id: string
+  name: string
+}
 export type RiskCategory = {
   created_at: string /*Date*/
   id: string
@@ -26,9 +30,7 @@ export type RiskCategory = {
 }
 
 export type PolicyItem = {
-  accountable_person_id?: string
-  accountable_dependent_id?: string
-  accountable_user_id?: string
+  accountable_person: AccountablePerson
   annual_premium: number
   category: any /*ItemCategory*/
   country: string

--- a/src/data/policy-members.ts
+++ b/src/data/policy-members.ts
@@ -1,5 +1,6 @@
 import { GET } from './index'
 import { derived, writable } from 'svelte/store'
+import { selectedPolicyId } from './role-policy-selection'
 
 export type PolicyMember = {
   email: string
@@ -12,6 +13,12 @@ export type PolicyMember = {
 }
 
 export const membersByPolicyId = writable<{ [policyId: string]: PolicyMember[] }>({})
+export const selectedPolicyMembers = derived(
+  [membersByPolicyId, selectedPolicyId],
+  ([$membersByPolicyId, $selectedPolicyId]) => {
+    return $membersByPolicyId[$selectedPolicyId] || []
+  }
+)
 export const allPolicyMembers = derived(membersByPolicyId, ($membersByPolicyId) => {
   return Object.values($membersByPolicyId).flat()
 })

--- a/src/pages/admin/home.svelte
+++ b/src/pages/admin/home.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
 import { CardsGrid, RecentActivityTable, Row } from 'components'
 import { loading } from 'components/progress'
-import { getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
 import type { Claim } from 'data/claims'
-import { allPolicyDependents, dependentsByPolicyId, loadDependents } from 'data/dependents'
 import type { PolicyItem } from 'data/items'
-import { allPolicyMembers, loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
-import { isRecentClaim, loadRecentActivity, RecentChange, recentChanges } from 'data/recent-activity'
+import { loadRecentActivity, recentChanges } from 'data/recent-activity'
 import { customerClaimDetails, itemDetails } from 'helpers/routes'
-import { uniq } from 'lodash-es'
 import { goto } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
@@ -18,25 +14,6 @@ onMount(() => {
   loadRecentActivity()
 })
 
-$: loadRecentActivityAdditionalData($recentChanges)
-
-$: dependents = $allPolicyDependents
-$: policyMembers = $allPolicyMembers
-
-$: dependentOptions = getDependentOptions(dependents)
-$: policyMemberOptions = getPolicyMemberOptions(policyMembers)
-$: accountablePersons = [...policyMemberOptions, ...dependentOptions]
-
-const loadRecentActivityAdditionalData = (recentChanges: RecentChange[]) => {
-  uniq(recentChanges.map((c) => (isRecentClaim(c) ? c.Claim : c.Item)?.policy_id)).forEach((policyId) => {
-    if (!Array.isArray($dependentsByPolicyId[policyId])) {
-      loadDependents(policyId)
-    }
-    if (!Array.isArray($membersByPolicyId[policyId])) {
-      loadMembersOfPolicy(policyId)
-    }
-  })
-}
 const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(event.detail.policy_id, event.detail.id))
 const onGotoPolicyItem = (event: CustomEvent<PolicyItem>) => $goto(itemDetails(event.detail.policy_id, event.detail.id))
 </script>
@@ -46,17 +23,11 @@ const onGotoPolicyItem = (event: CustomEvent<PolicyItem>) => $goto(itemDetails(e
 
 <Page layout="grid">
   <Row cols="12">
-    <CardsGrid
-      isAdmin
-      {accountablePersons}
-      recentChanges={$recentChanges}
-      on:goto-claim={onGotoClaim}
-      on:goto-item={onGotoPolicyItem}
-    />
+    <CardsGrid isAdmin recentChanges={$recentChanges} on:goto-claim={onGotoClaim} on:goto-item={onGotoPolicyItem} />
   </Row>
 
   <Row cols={'12'}>
     <h3>Recent activity</h3>
-    <RecentActivityTable {dependents} loading={$loading} {policyMembers} recentChanges={$recentChanges} />
+    <RecentActivityTable loading={$loading} recentChanges={$recentChanges} />
   </Row>
 </Page>

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 import { getNameOfPolicy, loadPolicy, Policy, PolicyType } from 'data/policies'
 import { loadItems, selectedPolicyItems } from 'data/items'
-import type { PolicyMember } from 'data/policy-members'
-import { getAccountablePerson, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
-import { dependentsByPolicyId } from 'data/dependents'
 import { formatDate } from 'components/dates'
 import { isLoadingById, loading } from 'components/progress'
 import { formatFriendlyDate } from 'helpers/date'
@@ -22,11 +19,7 @@ onMount(async () => {
   policy = await loadPolicy(policyId)
 })
 
-$: members = policy.members || ([] as PolicyMember[])
-$: policyMemberOptions = getPolicyMemberOptions(members)
-$: dependents = $dependentsByPolicyId[policyId] || []
-$: dependentOptions = getDependentOptions(dependents)
-$: accountablePersons = [...policyMemberOptions, ...dependentOptions]
+$: members = policy.members || []
 
 $: policyId && loadItems(policyId)
 $: items = $selectedPolicyItems
@@ -123,9 +116,7 @@ th {
               ><a href={itemDetails(policyId, item.id)}>{item.name || ''}</a> ({item.coverage_status ||
                 ''})</Datatable.Data.Row.Item
             >
-            <Datatable.Data.Row.Item
-              >{getAccountablePerson(item, accountablePersons).name || ''}</Datatable.Data.Row.Item
-            >
+            <Datatable.Data.Row.Item>{item.accountable_person?.name || ''}</Datatable.Data.Row.Item>
             <Datatable.Data.Row.Item>{formatMoney(item.coverage_amount)}</Datatable.Data.Row.Item>
             <Datatable.Data.Row.Item>{formatMoney(item.annual_premium)}</Datatable.Data.Row.Item>
             <Datatable.Data.Row.Item>{formatDate(item.updated_at)}</Datatable.Data.Row.Item>

--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 import { UserAppRole } from '../../../authn/user'
 import { ClaimCards, Row, Breadcrumb } from 'components'
-import { AccountablePersonOptions, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
-import { dependentsByPolicyId, loadDependents } from 'data/dependents'
 import { loadItems } from 'data/items'
 import { getNameOfPolicy, selectedPolicy } from 'data/policies'
-import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import { roleSelection } from 'data/role-policy-selection'
 import { customerClaims, customerClaimDetails, POLICIES, policyDetails } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -27,20 +24,11 @@ $: adminBreadcrumbs = isAdmin
   : []
 
 $: breadcrumbLinks = [...adminBreadcrumbs, { name: 'Claims', url: customerClaims(policyId) }]
-
-$: dependents = $dependentsByPolicyId[policyId] || []
-$: dependentOptions = getDependentOptions(dependents)
-
-$: policyMembers = $membersByPolicyId[policyId] || []
-$: policyMemberOptions = getPolicyMemberOptions(policyMembers)
-$: accountablePersons = [...policyMemberOptions, ...dependentOptions] as AccountablePersonOptions[]
 $: metatags.title = formatPageTitle('Claims')
 
 onMount(() => {
   loadItems(policyId)
   loadClaimsByPolicyId(policyId)
-  loadDependents(policyId)
-  loadMembersOfPolicy(policyId)
 })
 
 const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(event.detail.policy_id, event.detail.id))
@@ -54,7 +42,7 @@ const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(ev
 
   <Row cols={'12'}>
     {#if $selectedPolicyClaims.length}
-      <ClaimCards {accountablePersons} {isAdmin} claims={$selectedPolicyClaims} on:goto-claim={onGotoClaim} />
+      <ClaimCards {isAdmin} claims={$selectedPolicyClaims} on:goto-claim={onGotoClaim} />
     {:else}
       No claims at this time.
     {/if}

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -21,7 +21,6 @@ import {
 import { formatDate } from 'components/dates'
 import { loading } from 'components/progress'
 import { upload } from 'data'
-import { getAccountablePerson, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
 import {
   denyClaim,
   claimsFileAttach,
@@ -40,10 +39,8 @@ import {
   fixReceipt,
   ClaimFilePurpose,
 } from 'data/claims'
-import { dependentsByPolicyId, loadDependents } from 'data/dependents'
 import { loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
 import { getNameOfPolicy, getPolicyById, loadPolicy, memberBelongsToPolicy, policies, Policy } from 'data/policies'
-import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import { roleSelection, selectedPolicyId } from 'data/role-policy-selection'
 import { formatMoney } from 'helpers/money'
 import { customerClaimEdit, customerClaims, customerClaimDetails, POLICIES, policyDetails } from 'helpers/routes'
@@ -83,18 +80,6 @@ $: policyId && loadItems(policyId)
 $: item = items.find((itm) => itm.id === claimItem.item_id) || ({} as PolicyItem)
 
 $: isMemberOfPolicy = memberBelongsToPolicy($user.id, $policies, policyId)
-
-// Accountable persons
-$: policyId && loadDependents(policyId)
-$: dependents = $dependentsByPolicyId[policyId] || []
-$: dependentOptions = getDependentOptions(dependents)
-
-$: policyId && loadMembersOfPolicy(policyId)
-$: policyMembers = $membersByPolicyId[policyId] || []
-$: policyMemberOptions = getPolicyMemberOptions(policyMembers)
-
-$: accountablePersons = [...policyMemberOptions, ...dependentOptions]
-$: accountablePersonName = getAccountablePerson(item, accountablePersons)?.name
 
 // policies
 $: $policies && (policy = getPolicyById(policyId))
@@ -264,7 +249,7 @@ const isFileUploadedByPurpose = (purpose: ClaimFilePurpose, files: ClaimFile[]):
       <b>Covered value</b>
       <div>{formatMoney(item.coverage_amount)}</div>
       <br />
-      <b>{accountablePersonName || ''}</b>
+      <b>{item.accountable_person?.name || ''}</b>
       <br />
       <div class="left-detail">
         <b>Household ID</b>

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -2,32 +2,22 @@
 import { CardsGrid, ItemsTable, Row } from 'components'
 import { isLoadingPolicyItems, loading } from 'components/progress'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
-import { AccountablePersonOptions, getDependentOptions, getPolicyMemberOptions } from 'data/accountablePersons'
-import { dependentsByPolicyId, loadDependents } from 'data/dependents'
 import { deleteItem, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
 import { getNameOfPolicy, selectedPolicy } from 'data/policies'
-import { loadMembersOfPolicy, membersByPolicyId } from 'data/policy-members'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import * as routes from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Button, Page } from '@silintl/ui-components'
-
-let policyId: string
+import { onMount } from 'svelte'
 
 $: policyId = $selectedPolicyId
 
-$: policyId && loadItems(policyId)
-$: policyId && loadClaimsByPolicyId(policyId)
+onMount(() => {
+  loadItems(policyId)
+  loadClaimsByPolicyId(policyId)
+})
 
-$: policyId && loadDependents(policyId)
-$: dependents = $dependentsByPolicyId[policyId] || []
-$: dependentOptions = getDependentOptions(dependents)
-
-$: policyId && loadMembersOfPolicy(policyId)
-$: policyMembers = $membersByPolicyId[policyId] || []
-$: policyMemberOptions = getPolicyMemberOptions(policyMembers)
-$: accountablePersons = [...policyMemberOptions, ...dependentOptions] as AccountablePersonOptions[]
 $: metatags.title = formatPageTitle('Home')
 
 const onDelete = async (event: CustomEvent<any>) => {
@@ -52,7 +42,6 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
   <Row cols={'12'}>
     <h3>{getNameOfPolicy($selectedPolicy)} Policy</h3>
     <CardsGrid
-      {accountablePersons}
       claims={$selectedPolicyClaims}
       policyItems={$selectedPolicyItems}
       on:goto-claim={onGotoClaim}
@@ -62,13 +51,7 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
 
   <Row cols={'12'}>
     {#if $selectedPolicyItems.length > 0}
-      <ItemsTable
-        items={$selectedPolicyItems}
-        {accountablePersons}
-        {policyId}
-        on:delete={onDelete}
-        on:gotoItem={onGotoItem}
-      />
+      <ItemsTable items={$selectedPolicyItems} {policyId} on:delete={onDelete} on:gotoItem={onGotoItem} />
     {:else if $loading && isLoadingPolicyItems(policyId)}
       Loading items...
     {:else}

--- a/src/pages/policies/[policyId]/items/[itemId].svelte
+++ b/src/pages/policies/[policyId]/items/[itemId].svelte
@@ -3,7 +3,6 @@ import user, { UserAppRole } from '../../../../authn/user'
 import { Breadcrumb, ItemDeleteModal, ItemDetails } from 'components'
 import { loading } from 'components/progress'
 import { formatDate } from 'components/dates'
-import { loadDependents } from 'data/dependents'
 import {
   approveItem,
   deleteItem,
@@ -15,7 +14,6 @@ import {
   selectedPolicyItems,
 } from 'data/items'
 import { getNameOfPolicy, loadPolicy, memberBelongsToPolicy, policies, Policy } from 'data/policies'
-import { loadMembersOfPolicy } from 'data/policy-members'
 import { loadPolicyItemHistory, policyHistoryByItemId } from 'data/policy-history'
 import { items as itemsRoute, itemDetails, itemEdit, itemNewClaim, POLICIES, policyDetails } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -38,11 +36,6 @@ let denyDialogButtons: Dialog.AlertButton[] = []
 let denyDialogMessage: string
 
 $: isAdmin = $roleSelection !== UserAppRole.Customer
-
-// Accountable persons
-$: policyId && loadDependents(policyId)
-
-$: policyId && loadMembersOfPolicy(policyId)
 
 $: items = $selectedPolicyItems
 $: item = items.find((itm) => itm.id === itemId) || ({} as PolicyItem)

--- a/src/pages/policies/[policyId]/items/[itemId]/edit.svelte
+++ b/src/pages/policies/[policyId]/items/[itemId]/edit.svelte
@@ -10,16 +10,19 @@ import { formatPageTitle } from 'helpers/pageTitle'
 import { HOME, items as itemsRoute, itemDetails, itemEdit } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
+import { onMount } from 'svelte'
 
 export let itemId: string
 export let policyId = $selectedPolicyId
 
 let isCheckingOut: boolean = false
 
-$: policyId && loadDependents(policyId)
-$: policyId && loadMembersOfPolicy(policyId)
+onMount(() => {
+  loadDependents(policyId)
+  loadMembersOfPolicy(policyId)
+  loadItems(policyId)
+})
 
-$: policyId && loadItems(policyId)
 $: items = $selectedPolicyItems
 $: item = items.find((anItem) => anItem.id === itemId) || ({} as PolicyItem)
 $: itemName = item.name || ''

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -8,14 +8,18 @@ import { formatPageTitle } from 'helpers/pageTitle'
 import { HOME, items as itemsRoute, itemDetails, itemsNew } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
+import { onMount } from 'svelte'
 
 export let policyId: string
 
 let isCheckingOut: boolean = false
 let item: PolicyItem
 
-$: policyId && loadDependents(policyId)
-$: policyId && loadMembersOfPolicy(policyId)
+onMount(() => {
+  loadDependents(policyId)
+  loadMembersOfPolicy(policyId)
+})
+
 $: metatags.title = formatPageTitle('Items > New')
 
 $: policyId && loadItems(policyId)

--- a/src/pages/policies/[policyId]/settings.svelte
+++ b/src/pages/policies/[policyId]/settings.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import user from '../../../authn/user'
 import { Breadcrumb, Description, SearchableSelect } from 'components'
-import { dependentsByPolicyId, loadDependents } from 'data/dependents'
+import { loadDependents, selectedPolicyDependents } from 'data/dependents'
 import { entityCodes, loadEntityCodes } from 'data/entityCodes'
 import { policies, updatePolicy, Policy, PolicyType, loadPolicy } from 'data/policies'
-import { loadMembersOfPolicy, membersByPolicyId, PolicyMember } from 'data/policy-members'
+import { loadMembersOfPolicy, PolicyMember, selectedPolicyMembers } from 'data/policy-members'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import { householdSettingsDependent, householdSettingsNewDependent, settingsPolicy } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -38,8 +38,8 @@ $: if (policyId) {
 $: $entityCodes.forEach((code) => {
   entityOptions[code.name] = code.code
 })
-$: dependents = $dependentsByPolicyId[policyId] || []
-$: householdMembers = $membersByPolicyId[policyId] || []
+$: dependents = $selectedPolicyDependents
+$: householdMembers = $selectedPolicyMembers
 $: policy = $policies.find((policy) => policy.id === policyId) || ({} as Policy)
 
 $: setInitialValues(policy)

--- a/src/pages/policies/[policyId]/settings/dependents/[uuid].svelte
+++ b/src/pages/policies/[policyId]/settings/dependents/[uuid].svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
 import { DependentForm } from 'components'
-import { deleteDependent, dependentsByPolicyId, loadDependents, updateDependent } from 'data/dependents'
+import { deleteDependent, loadDependents, selectedPolicyDependents, updateDependent } from 'data/dependents'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import { settingsPolicy } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
+import { onMount } from 'svelte'
 
 export let uuid: string
 
 $: policyId = $selectedPolicyId
-$: policyId && loadDependents(policyId)
+onMount(() => {
+  loadDependents(policyId)
+})
 
-$: dependents = $dependentsByPolicyId[policyId] || []
+$: dependents = $selectedPolicyDependents
 $: dependent = dependents.find((d) => uuid && d.id === uuid)
 $: metatags.title = formatPageTitle(`Settings > Household > Edit Dependent`)
 

--- a/src/pages/policies/[policyId]/settings/dependents/new.svelte
+++ b/src/pages/policies/[policyId]/settings/dependents/new.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
 import { DependentForm } from 'components'
-import { addDependent, dependentsByPolicyId, loadDependents } from 'data/dependents'
+import { addDependent, loadDependents, selectedPolicyDependents } from 'data/dependents'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import { settingsPolicy } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
+import { onMount } from 'svelte'
 
 $: policyId = $selectedPolicyId
+onMount(() => {
+  loadDependents(policyId)
+})
 
-$: policyId && loadDependents(policyId)
-$: dependents = $dependentsByPolicyId[policyId] || []
+$: dependents = $selectedPolicyDependents
 $: metatags.title = formatPageTitle('Settings > Household > Add Dependent')
 
 const onCancel = () => {


### PR DESCRIPTION
The response body for PolicyItems has changed such that 'accountable_person' now contains both the id and user-friendly name of the accountable person (instead of just an id). This means that we can rip up TONS of now-dead code that was doing fangaly data loads and look-up in order to retrieve this data.
The remaining places where we still need to do a load'n'look-up for policy dependent/member data is in the following cases
* when we are creating a new policy item
* when we are editing a policy item
* when we are editing policy settings and policy dependent settings