### PR TITLE
approve FMV & FixedFraction instead of preapprove

### DIFF
--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Claim, ClaimStatus, editableStatuses } from 'data/claims'
+import { Claim, ClaimStatus, editableStatuses, PayoutOption } from 'data/claims'
 import Description from './Description.svelte'
 import { throwError } from '../error'
 import { Button, TextField } from '@silintl/ui-components'
@@ -11,6 +11,7 @@ export let needsFile: boolean
 export let isMemberOfPolicy: boolean
 export let isAdmin: boolean
 export let receiptType: string
+export let payoutOption: PayoutOption
 
 const dispatch = createEventDispatcher()
 
@@ -22,10 +23,11 @@ $: approveButtonLabel = receiptType === 'Replacement' ? 'replace' : 'repair'
 
 let action: string
 let actionLabel: string
+$: isFMVorEvacuation = payoutOption === 'FMV' || payoutOption === 'FixedFraction'
 $: switch (status) {
   case 'Review1':
-    action = 'preapprove'
-    actionLabel = `okay to ${approveButtonLabel}`
+    action = isFMVorEvacuation ? 'approve' : 'preapprove'
+    actionLabel = isFMVorEvacuation ? 'approve payout' : `okay to ${approveButtonLabel}`
     break
   case 'Review2':
     action = 'approve'

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -301,6 +301,7 @@ const isFileUploadedByPurpose = (purpose: ClaimFilePurpose, files: ClaimFile[]):
           {isAdmin}
           {isMemberOfPolicy}
           {receiptType}
+          {payoutOption}
           on:ask-for-changes={onAskForChanges}
           on:deny={onDenyClaim}
           on:edit={editClaim}


### PR DESCRIPTION
- We can skip `claim.status: Receipt` by using ClaimsApprove endpoint instead of PreApprove
- FMV and FixedFraction  don't require a receipt so we use ClaimsApprove