### PR TITLE
Remove `Review3a`/`Review3b` and update claim statuses awaiting admins

### DIFF
--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -10,9 +10,7 @@ export type ClaimItemStatus =
   | 'Draft'
   | 'Review1'
   | 'Review2'
-  | 'Review3' // TODO: Remove once API is updated to use Review3a / Review3b.
-  | 'Review3a'
-  | 'Review3b'
+  | 'Review3'
   | 'Revision'
   | 'Receipt'
   | 'Approved'
@@ -23,9 +21,7 @@ export type ClaimStatus =
   | 'Draft'
   | 'Review1'
   | 'Review2'
-  | 'Review3' // TODO: Remove once API is updated to use Review3a / Review3b.
-  | 'Review3a'
-  | 'Review3b'
+  | 'Review3'
   | 'Revision'
   | 'Receipt'
   | 'Approved'
@@ -153,28 +149,17 @@ export const selectedPolicyClaims = derived([claims, selectedPolicyId], ([$claim
 })
 export const initialized = writable<boolean>(false)
 
-export const editableStatuses: ClaimStatus[] = [
-  'Draft',
-  'Review1',
-  'Review2',
-  'Review3',
-  'Review3a',
-  'Review3b',
-  'Revision',
-  'Receipt',
-]
+export const editableStatuses: ClaimStatus[] = ['Draft', 'Review1', 'Review2', 'Review3', 'Revision', 'Receipt']
 export const incompleteClaimItemStatuses: ClaimItemStatus[] = [
   'Draft',
   'Review1',
   'Review2',
-  'Review3', // TODO: Remove once API is updated to use Review3a / Review3b.
-  'Review3a',
-  'Review3b',
+  'Review3',
   'Revision',
   'Receipt',
 ]
-export const statusesAwaitingSteward: ClaimStatus[] = ['Review1', 'Review2', 'Review3', 'Review3b']
-export const statusesAwaitingSignator: ClaimStatus[] = ['Review1', 'Review2', 'Review3', 'Review3a']
+export const statusesAwaitingSteward: ClaimStatus[] = ['Review1', 'Review2']
+export const statusesAwaitingSignator: ClaimStatus[] = ['Review3']
 
 /**
  * Update a claim in our local list (store) of claims.
@@ -319,7 +304,7 @@ export const denyClaim = async (claimId: string, reason: string): Promise<void> 
 
 /**
  * Admin reverts a claim to request a new/better receipt. Can be used at state
- * "Review2" or "Review3"/"Review3a"/"Review3b".
+ * "Review2" or "Review3".
  *
  * @export
  * @param {String} claimId

--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -63,8 +63,6 @@ export const claimStates: { [stateName: string]: State } = {
   Review1: pendingClaim,
   Review2: pendingClaim,
   Review3: pendingClaim,
-  Review3a: pendingClaim,
-  Review3b: pendingClaim,
   ReceiptSecondary: warning,
   Receipt: { ...approved, icon: 'done' },
   Paid: {
@@ -78,8 +76,6 @@ export const adminClaimStates: { [stateName: string]: State } = {
   Review1: needsReview,
   Review2: { ...needsReview, title: 'Needs receipt review' },
   Review3: { ...needsReview, title: 'Needs final claim review' },
-  Review3a: { ...needsReview, title: 'Needs final claim review' },
-  Review3b: { ...needsReview, title: 'Needs final claim review' },
   Revision: { ...pending, title: 'Awaiting changes' },
   Receipt: { ...pending, icon: 'check_circle', title: 'Approved' },
   ReceiptSecondary: { ...pending, title: 'Awaiting changes' },


### PR DESCRIPTION
### Changed
- Remove `Review3a` and `Review3b` statuses
- Update which claims statuses we show as awaiting each admin role

The new design is that Steward can do Review1 and Review2, and Signator can do Review3.

---

@hobbitronics, I did not modify the ClaimActions component, since it sounded like you would be handling those changes and they looked more involved that just removing entries from a list.