### PR TITLE
add session resume feature

### DIFF
--- a/src/authn/session.ts
+++ b/src/authn/session.ts
@@ -1,0 +1,20 @@
+import * as routes from 'helpers/routes'
+import { writable } from 'svelte/store'
+
+export const initialized = writable<boolean>(false)
+
+export const getLastPath = (): { path: string; lastSet: number } => {
+  return {
+    path: localStorage.getItem('last-path') || '',
+    lastSet: Number(localStorage.getItem('last-path-set')),
+  }
+}
+
+const lastPathBlacklist = [routes.ROOT, routes.HOME, routes.LOGOUT, routes.LOGGEDOUT]
+export const setLastPath = (path: string): void => {
+  if (!lastPathBlacklist.includes(path)) {
+    initialized.set(true)
+    localStorage.setItem('last-path', path)
+    localStorage.setItem('last-path-set', String(Date.now()))
+  }
+}

--- a/src/authn/session.ts
+++ b/src/authn/session.ts
@@ -12,9 +12,10 @@ export const getLastPath = (): { path: string; lastSet: number } => {
 
 const lastPathBlacklist = [routes.ROOT, routes.HOME, routes.LOGOUT, routes.LOGGEDOUT]
 export const setLastPath = (path: string): void => {
+  localStorage.setItem('last-path-set', String(Date.now()))
+
   if (!lastPathBlacklist.includes(path)) {
     initialized.set(true)
     localStorage.setItem('last-path', path)
-    localStorage.setItem('last-path-set', String(Date.now()))
   }
 }

--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -6,15 +6,18 @@ import './mdc/_index.scss'
 import t from '../i18n'
 import FreshdeskWidget from './FreshdeskWidget.svelte'
 import { parse, stringify } from 'qs'
-import { afterPageLoad, Router } from '@roxi/routify'
+import { afterPageLoad, route, Router } from '@roxi/routify'
 import { routes } from '../../.routify/routes'
 import { Snackbar } from '@silintl/ui-components'
+import { setLastPath } from '../authn/session'
 
 // If we've loaded the user, but their policy wasn't quite ready, try again.
 $: if (!$user.policy_id && isCustomer($user)) {
   //TODO remove this when fixed on the backend
   setTimeout(() => loadUser(true), 5000)
 }
+
+$: $route && $user && setLastPath(location.pathname)
 
 // added because of this:  https://github.com/sveltech/routify/issues/201
 const queryHandler = {

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -4,6 +4,7 @@ import qs from 'qs'
 export const ROOT = '/'
 export const HOME = '/home'
 export const LOGOUT = '/logout'
+export const LOGGEDOUT = '/logged-out'
 
 export const ADMIN_HOME = '/admin/home'
 export const ADMIN_POLICIES = '/admin/policies'

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -1,10 +1,23 @@
 <script lang="ts">
 import { UserAppRole } from '../authn/user'
+import { getLastPath, initialized } from '../authn/session'
 import { ADMIN_HOME, CUSTOMER_HOME } from 'helpers/routes'
+import { add, isBefore } from 'date-fns'
 import { redirect } from '@roxi/routify'
 import { roleSelection } from 'data/role-policy-selection'
 
-$: sendToRoleHome($roleSelection)
+$: {
+  const lastPath = getLastPath()
+  // if the last path was set withing the last 5 minutes assume we want to resume the session
+  // only ever redirect to the last path once per session
+  const shouldResumeSession = lastPath && !$initialized && isBefore(Date.now(), add(lastPath.lastSet, { minutes: 5 }))
+  if (shouldResumeSession) {
+    initialized.set(true)
+    $redirect(lastPath.path)
+  } else {
+    sendToRoleHome($roleSelection)
+  }
+}
 
 const sendToRoleHome = (appRole: string) => {
   switch (appRole) {

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -12,7 +12,7 @@ $: {
   // only ever redirect to the last path once per session
   const shouldResumeSession = lastPath && !$initialized && isBefore(Date.now(), add(lastPath.lastSet, { minutes: 5 }))
   if (shouldResumeSession) {
-    initialized.set(true)
+    $initialized = true
     $redirect(lastPath.path)
   } else {
     sendToRoleHome($roleSelection)


### PR DESCRIPTION
* keep track of the last route the user has visited and the time they visited
* the first time we arrive at the default home page (which is where the post-login process will drop a user) check if we should resume the prior "session"