### PR TITLE
fix(Card): Allow each policy card in each row to auto expand it's height

### DIFF
--- a/src/components/ClaimCard.svelte
+++ b/src/components/ClaimCard.svelte
@@ -60,7 +60,7 @@ const gotoClaim = () => dispatch('goto-claim', claim)
 }
 </style>
 
-<Card noPadding class="h-300 py-0 {$$props.class}">
+<Card noPadding class="py-0 h-100 {$$props.class}">
   <ClaimCardBanner
     class={showSecondBanner ? 'mb-0 pb-4px pt-6px' : 'mb-2'}
     {statusReason}
@@ -74,7 +74,7 @@ const gotoClaim = () => dispatch('goto-claim', claim)
     </ClaimBanner>
   {/if}
 
-  <div class="mdc-typography--headline5 multi-line-truncate content ml-50px">
+  <div class="mdc-typography--headline5 content ml-50px">
     {item.name || ''}
   </div>
 

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -49,10 +49,10 @@ const gotoItem = () => dispatch('goto-item', item)
 }
 </style>
 
-<Card noPadding class="h-300 py-0 {$$props.class}">
+<Card noPadding class="h-100 py-0 {$$props.class}">
   <ClaimCardBanner {statusReason} {state} {showRevisionMessage} />
 
-  <div class="mdc-typography--headline5 multi-line-truncate content ml-50px">
+  <div class="mdc-typography--headline5 content ml-50px">
     {item.name || ''}
   </div>
 


### PR DESCRIPTION
Now each card will auto expand to match the largest sibling's height in same row:

![image](https://user-images.githubusercontent.com/20076677/141831408-8bc25827-9598-4e4f-95a9-b68a513c27b5.png)
