### PR TITLE
removed faq, Items and Claims from Admin roles

### DIFF
--- a/src/components/AppDrawer.svelte
+++ b/src/components/AppDrawer.svelte
@@ -10,7 +10,7 @@ import { ROOT } from 'helpers/routes'
 
 export let menuItems: any[]
 export let myPolicies: Policy[]
-export let role: UserAppRole | undefined
+export let role: UserAppRole
 
 let toggle = false
 

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import user, { isAdmin, UserAppRole } from '../authn/user'
+import user, { isAdmin } from '../authn/user'
 import { AppDrawer } from 'components'
-import { initialized as policiesInitialized, loadPolicies, policies, Policy } from 'data/policies'
+import { initialized as policiesInitialized, loadPolicies } from 'data/policies'
 import * as routes from 'helpers/routes'
 import { goto } from '@roxi/routify'
 import { roleSelection, selectedPolicyId } from 'data/role-policy-selection'
@@ -12,8 +12,7 @@ $: $policiesInitialized || loadPolicies()
 
 $: myPolicies = $user?.policies || []
 $: policyId = $selectedPolicyId || $user.policy_id
-$: inAdminRole =
-  isAdmin($user.app_role) && ($roleSelection === UserAppRole.Steward || $roleSelection === UserAppRole.Signator)
+$: inAdminRole = isAdmin($roleSelection)
 
 // TODO: Update this based on the user's role and/or the RoleAndPolicyMenu selection.
 $: menuItems = [
@@ -33,16 +32,19 @@ $: menuItems = [
     url: routes.ITEMS,
     icon: 'umbrella',
     label: 'items',
+    hide: inAdminRole,
   },
   {
     url: inAdminRole ? routes.ADMIN_HOME : routes.customerClaims(policyId),
     icon: 'label',
     label: 'Claims',
+    hide: inAdminRole,
   },
   {
     url: routes.FAQ,
     icon: 'quiz',
     label: 'FAQ',
+    hide: true,
   },
   // {
   //   url: routes.CHAT,

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -35,7 +35,7 @@ $: menuItems = [
     hide: inAdminRole,
   },
   {
-    url: inAdminRole ? routes.ADMIN_HOME : routes.customerClaims(policyId),
+    url: routes.customerClaims(policyId),
     icon: 'label',
     label: 'Claims',
     hide: inAdminRole,


### PR DESCRIPTION
- remove Drawer menu items for admins as they all go to admin/home and cause the wrong item to be highlighted
- remove faq

- we may want to show a different view for them at some point but for now they seem to serve no purpose