### PR TITLE
stay on current page when changing role/policy

### DIFF
--- a/src/authn/user.ts
+++ b/src/authn/user.ts
@@ -72,8 +72,7 @@ export const isSignator = (userRole: UserAppRole): boolean => userRole === UserA
 export const isAdmin = (userRole: UserAppRole): boolean =>
   isUserSteward(userRole) || isSignator(userRole) || userRole === UserAppRole.Admin
 
-export const isCustomer = (userRole: UserAppRole): boolean =>
-  !isUserSteward(userRole) && !isSignator(userRole) && !!userRole
+export const isCustomer = (userRole: UserAppRole): boolean => userRole === UserAppRole.Customer
 
 export const getDefaultPolicyId = (user: User): string => {
   const policies = user.policies || []

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -65,7 +65,7 @@ const getHouseholdEntries = (policies: Policy[]): MenuItem[] => {
 
 const selectRole = (role: UserAppRole) => {
   recordRoleSelection(role)
-  dispatch('role', role)
+  dispatch('role', { role, policyId: $selectedPolicyId })
 }
 
 const getEntriesForRole = (role: UserAppRole): MenuItem[] => {

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -71,7 +71,7 @@ const isCustomerOnOwnPolicy = (policyId: string) => policyId === $selectedPolicy
 const gotoPath = (policyId: string, claimOrItemIdObj = {}) =>
   $goto($url($route.path, { policyId, ...claimOrItemIdObj }))
 
-const goToPolicyAsCustomer = (event: CustomEvent) => {
+const goToCustomerView = (event: CustomEvent) => {
   if ($params.policyId && !$params.claimId && !$params.itemId) {
     gotoPath(event.detail)
   } else if ($params.policyId && ($params.claimId || $params.itemId) && isCustomerOnOwnPolicy(event.detail)) {
@@ -91,6 +91,6 @@ const goToAdminView = (event: CustomEvent) => {
 }
 </script>
 
-<AppDrawer {menuItems} {myPolicies} role={$user.app_role} on:policy={goToPolicyAsCustomer} on:role={goToAdminView}>
+<AppDrawer {menuItems} {myPolicies} role={$user.app_role} on:policy={goToCustomerView} on:role={goToAdminView}>
   <slot />
 </AppDrawer>

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -82,11 +82,14 @@ const goToCustomerView = (event: CustomEvent) => {
   }
 }
 const goToAdminView = (event: CustomEvent) => {
-  if ($params.policyId && ($params.claimId || $params.itemId)) {
-    const claimOrItemIdObj = $params.claimId ? { claimId: $params.claimId } : { itemId: $params.itemId }
-    gotoPath(event.detail.policyId, claimOrItemIdObj)
-  } else if ($params.policyId) {
-    gotoPath(event.detail.policyId)
+  if ($params.policyId) {
+    if ($params.claimId) {
+      gotoPath(event.detail.policyId, { claimId: $params.claimId })
+    } else if ($params.itemId) {
+      gotoPath(event.detail.policyId, { itemId: $params.itemId })
+    } else {
+      gotoPath(event.detail.policyId)
+    }
   } else {
     $goto(routes.ADMIN_HOME)
   }

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -13,6 +13,7 @@ $: $policiesInitialized || loadPolicies()
 $: myPolicies = $user?.policies || []
 $: policyId = $selectedPolicyId || $user.policy_id
 $: inAdminRole = isAdmin($roleSelection)
+$: urlIsClaimOrItem = $params.claimId || $params.itemId
 
 // TODO: Update this based on the user's role and/or the RoleAndPolicyMenu selection.
 $: menuItems = [
@@ -71,9 +72,9 @@ const isCustomerOnOwnPolicy = (policyId: string) => policyId === $selectedPolicy
 const gotoPath = (policyId: string, claimOrItemIdObj = {}) => $goto($route.path, { policyId, ...claimOrItemIdObj })
 
 const goToCustomerView = (event: CustomEvent) => {
-  if ($params.policyId && !$params.claimId && !$params.itemId) {
+  if (!urlIsClaimOrItem && $params.policyId) {
     gotoPath(event.detail)
-  } else if ($params.policyId && ($params.claimId || $params.itemId) && isCustomerOnOwnPolicy(event.detail)) {
+  } else if (urlIsClaimOrItem && isCustomerOnOwnPolicy(event.detail)) {
     const claimOrItemIdObj = $params.claimId ? { claimId: $params.claimId } : { itemId: $params.itemId }
     gotoPath(event.detail, claimOrItemIdObj)
   } else {

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -66,6 +66,7 @@ $: menuItems = [
     hide: inAdminRole || !policyId,
   },
 ]
+const isCustomerOnOwnPolicy = (policyId: string) => policyId === $selectedPolicyId
 
 const gotoPath = (policyId: string, claimOrItemIdObj = {}) =>
   $goto($url($route.path, { policyId, ...claimOrItemIdObj }))
@@ -73,8 +74,7 @@ const gotoPath = (policyId: string, claimOrItemIdObj = {}) =>
 const goToPolicyAsCustomer = (event: CustomEvent) => {
   if ($params.policyId && !$params.claimId && !$params.itemId) {
     gotoPath(event.detail)
-  } else if ($params.policyId && ($params.claimId || $params.itemId)) {
-    //TODO check if item/claim belongs to new selected policy
+  } else if ($params.policyId && ($params.claimId || $params.itemId) && isCustomerOnOwnPolicy(event.detail)) {
     const claimOrItemIdObj = $params.claimId ? { claimId: $params.claimId } : { itemId: $params.itemId }
     gotoPath(event.detail, claimOrItemIdObj)
   } else {

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -69,7 +69,7 @@ $: menuItems = [
 const isCustomerOnOwnPolicy = (policyId: string) => policyId === $selectedPolicyId
 
 const gotoPath = (policyId: string, claimOrItemIdObj = {}) =>
-  $goto($url($route.path, { policyId, ...claimOrItemIdObj }))
+  $goto($route.path, { policyId, ...claimOrItemIdObj })
 
 const goToCustomerView = (event: CustomEvent) => {
   if ($params.policyId && !$params.claimId && !$params.itemId) {

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -85,6 +85,8 @@ const goToAdminView = (event: CustomEvent) => {
   if ($params.policyId && ($params.claimId || $params.itemId)) {
     const claimOrItemIdObj = $params.claimId ? { claimId: $params.claimId } : { itemId: $params.itemId }
     gotoPath(event.detail.policyId, claimOrItemIdObj)
+  } else if ($params.policyId) {
+    gotoPath(event.detail.policyId)
   } else {
     $goto(routes.ADMIN_HOME)
   }

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -68,8 +68,7 @@ $: menuItems = [
 ]
 const isCustomerOnOwnPolicy = (policyId: string) => policyId === $selectedPolicyId
 
-const gotoPath = (policyId: string, claimOrItemIdObj = {}) =>
-  $goto($route.path, { policyId, ...claimOrItemIdObj })
+const gotoPath = (policyId: string, claimOrItemIdObj = {}) => $goto($route.path, { policyId, ...claimOrItemIdObj })
 
 const goToCustomerView = (event: CustomEvent) => {
   if ($params.policyId && !$params.claimId && !$params.itemId) {


### PR DESCRIPTION
- this allows the customer/admin to stay on a claim/item but change roles or stay on settings and change policy
- the customer will not be able to view the same claim/item when switching policies so will be sent to home