### PR TITLE
Remove the `UserAppRole.Admin` role

### DIFF
--- a/src/authn/user.ts
+++ b/src/authn/user.ts
@@ -6,7 +6,6 @@ export enum UserAppRole {
   Customer = 'Customer',
   Steward = 'Steward',
   Signator = 'Signator',
-  Admin = 'Admin',
 }
 
 export type User = {
@@ -69,8 +68,7 @@ export const isUserSteward = (userRole: UserAppRole): boolean => userRole === Us
 
 export const isSignator = (userRole: UserAppRole): boolean => userRole === UserAppRole.Signator
 
-export const isAdmin = (userRole: UserAppRole): boolean =>
-  isUserSteward(userRole) || isSignator(userRole) || userRole === UserAppRole.Admin
+export const isAdmin = (userRole: UserAppRole): boolean => isUserSteward(userRole) || isSignator(userRole)
 
 export const isCustomer = (userRole: UserAppRole): boolean => userRole === UserAppRole.Customer
 

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -26,7 +26,6 @@ const sendToRoleHome = (appRole: string) => {
       break
     case UserAppRole.Steward:
     case UserAppRole.Signator:
-    case UserAppRole.Admin:
       $redirect(ADMIN_HOME)
       break
     case undefined:


### PR DESCRIPTION
### Fixed
- Remove the `UserAppRole.Admin` role

---

It has already been removed from the backend. This resolves the naming collision we had between an actual `Admin` role vs. our convention of referring to any Steward or Signator as an "admin".