### PR TITLE
add NoHouseholdId modal

### DIFF
--- a/src/components/NoHouseholdIdModal.svelte
+++ b/src/components/NoHouseholdIdModal.svelte
@@ -2,13 +2,13 @@
 import { Dialog } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
-export let open = true
+export let open = false
 
 let message = 'A household ID is required before getting coverage. Add it in Policy Settings.'
 let title = 'Missing information'
 
 const buttons: Dialog.AlertButton[] = [
-  { label: 'cancel', action: 'cancel', class: 'mdc-dialog__button' },
+  { label: 'Go Back', action: 'cancel', class: 'mdc-dialog__button' },
   { label: 'Policy Settings', action: 'gotoSettings', class: 'mdc-button--raised' },
 ]
 

--- a/src/components/NoHouseholdIdModal.svelte
+++ b/src/components/NoHouseholdIdModal.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { Dialog } from '@silintl/ui-components'
+import { createEventDispatcher } from 'svelte'
+
+export let open = true
+
+let message = 'A household ID is required before getting coverage. Add it in Policy Settings.'
+let title = 'Missing information'
+
+const buttons: Dialog.AlertButton[] = [
+  { label: 'cancel', action: 'cancel', class: 'mdc-dialog__button' },
+  { label: 'Policy Settings', action: 'gotoSettings', class: 'mdc-button--raised' },
+]
+
+const dispatch = createEventDispatcher<{ closed: string }>()
+
+const handleDialog = (choice: string) => {
+  open = false
+  dispatch('closed', choice)
+}
+</script>
+
+<Dialog.Alert
+  {open}
+  {buttons}
+  defaultAction="cancel"
+  {title}
+  on:chosen={(e) => handleDialog(e.detail)}
+  on:closed={handleDialog}>{message}</Dialog.Alert
+>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ import ItemDetails from './ItemDetails.svelte'
 import ItemForm from './forms/ItemForm.svelte'
 import ItemsTable from './ItemsTable.svelte'
 import MoneyInput from './MoneyInput.svelte'
+import NoHouseholdIdModal from './NoHouseholdIdModal.svelte'
 import RadioOptions from './RadioOptions.svelte'
 import RecentActivityTable from './RecentActivityTable.svelte'
 import Row from './mdc/Row.svelte'
@@ -47,6 +48,7 @@ export {
   ItemForm,
   ItemsTable,
   MoneyInput,
+  NoHouseholdIdModal,
   RadioOptions,
   CardsGrid,
   ClaimCard,

--- a/src/pages/policies/[policyId]/home.svelte
+++ b/src/pages/policies/[policyId]/home.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-import { CardsGrid, ItemsTable, Row } from 'components'
+import { CardsGrid, ItemsTable, NoHouseholdIdModal, Row } from 'components'
 import { isLoadingPolicyItems, loading } from 'components/progress'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
 import { deleteItem, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
-import { getNameOfPolicy, selectedPolicy } from 'data/policies'
+import { getNameOfPolicy, PolicyType, selectedPolicy } from 'data/policies'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import * as routes from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Button, Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
+
+let open = false
 
 $: policyId = $selectedPolicyId
 $: items = $selectedPolicyItems.filter((item) => item.coverage_status !== 'Inactive')
@@ -37,6 +39,19 @@ const onGotoPolicyItem = (event: CustomEvent<PolicyItem>) =>
   $goto(routes.itemDetails(event.detail.policy_id, event.detail.id))
 
 const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
+
+const onAddItem = () => {
+  if ($selectedPolicy.household_id || $selectedPolicy.type === PolicyType.Team) {
+    $goto(routes.itemsNew(policyId))
+  } else {
+    open = true
+  }
+}
+
+const onClosed = (event: CustomEvent<any>) => {
+  event.detail === 'gotoSettings' && $goto(routes.settingsPolicy(policyId))
+  open = false
+}
 </script>
 
 <Page layout="grid">
@@ -58,8 +73,9 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
     {:else}
       <p class="text-align-center">You don't have any items in this policy</p>
       <p class="text-align-center">
-        <Button class="m-1" raised prependIcon="add_circle" url={routes.itemsNew(policyId)}>Add Item</Button>
+        <Button class="m-1" raised prependIcon="add_circle" on:click={onAddItem}>Add Item</Button>
       </p>
+      <NoHouseholdIdModal {open} on:closed={onClosed} />
     {/if}
   </Row>
 </Page>

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-import { CardsGrid, ItemsTable, Row } from 'components'
+import { CardsGrid, ItemsTable, NoHouseholdIdModal, Row } from 'components'
 import { isLoadingPolicyItems, loading } from 'components/progress'
 import { deleteItem, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
-import { getNameOfPolicy, selectedPolicy } from 'data/policies'
+import { getNameOfPolicy, PolicyType, selectedPolicy } from 'data/policies'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import * as routes from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Button, Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
+
+let open = false
 
 $: policyId = $selectedPolicyId
 $: activeItems = $selectedPolicyItems.filter((item) => item.coverage_status !== 'Inactive')
@@ -33,6 +35,19 @@ const onGotoPolicyItem = (event: CustomEvent<PolicyItem>) =>
   $goto(routes.itemDetails(event.detail.policy_id, event.detail.id))
 
 const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
+
+const onAddItem = () => {
+  if ($selectedPolicy.household_id || $selectedPolicy.type === PolicyType.Team) {
+    $goto(routes.itemsNew(policyId))
+  } else {
+    open = true
+  }
+}
+
+const onClosed = (event: CustomEvent<any>) => {
+  event.detail === 'gotoSettings' && $goto(routes.settingsPolicy(policyId))
+  open = false
+}
 </script>
 
 <Page layout="grid">
@@ -65,8 +80,9 @@ const onGotoItem = (event: CustomEvent<string>) => $goto(event.detail)
     {:else}
       <p class="text-align-center">You don't have any items in this policy</p>
       <p class="text-align-center">
-        <Button class="m-1" raised prependIcon="add_circle" url={routes.itemsNew(policyId)}>Add Item</Button>
+        <Button class="m-1" raised prependIcon="add_circle" on:click={onAddItem}>Add Item</Button>
       </p>
+      <NoHouseholdIdModal {open} on:closed={onClosed} />
     {/if}
   </Row>
 </Page>

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
 import Checkout from 'Checkout.svelte'
-import { Breadcrumb, ItemForm } from 'components'
+import { Breadcrumb, ItemForm, NoHouseholdIdModal } from 'components'
 import { loadDependents } from 'data/dependents'
 import { addItem, deleteItem, loadItems, PolicyItem, submitItem } from 'data/items'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { HOME, items as itemsRoute, itemDetails, itemsNew } from 'helpers/routes'
+import { HOME, items as itemsRoute, itemDetails, itemsNew, settingsPolicy } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
+import { PolicyType, selectedPolicy } from 'data/policies'
 
 export let policyId: string
 
-let isCheckingOut: boolean = false
+let isCheckingOut = false
 let item: PolicyItem
+let open = false
 
 onMount(() => {
   loadDependents(policyId)
@@ -23,6 +25,8 @@ onMount(() => {
 $: metatags.title = formatPageTitle('Items > New')
 
 $: policyId && loadItems(policyId)
+
+$: $selectedPolicy.type === PolicyType.Household && !$selectedPolicy.household_id && (open = true)
 
 $: breadcrumbLinks = [
   { name: 'Items', url: itemsRoute(policyId) },
@@ -54,12 +58,19 @@ const onDelete = async (event: CustomEvent<string>) => {
 const onEdit = () => {
   isCheckingOut = false
 }
+
+const onClosed = (event: CustomEvent<any>) => {
+  event.detail === 'gotoSettings' && $goto(settingsPolicy(policyId))
+  history.back()
+  open = false
+}
 </script>
 
 <Page>
   {#if !isCheckingOut}
     <Breadcrumb links={breadcrumbLinks} />
     <ItemForm {item} {policyId} on:submit={onApply} on:save-for-later={onSaveForLater} />
+    <NoHouseholdIdModal {open} on:closed={onClosed} />
   {:else}
     <Checkout {item} {policyId} on:agreeAndPay={onAgreeAndPay} on:delete={onDelete} on:edit={onEdit} />
   {/if}


### PR DESCRIPTION
- Customers without household Id could fill out a form but would be rejected on submitting it.
- add the modal to the new view since I cant make the `Drawer` button trigger it (urls only)
- add to views that have a "Add Item" button (to prevent too much url jumping to the form and back)