### PR TITLE
Use countries list from API

### DIFF
--- a/src/data/countries.ts
+++ b/src/data/countries.ts
@@ -1,0 +1,17 @@
+import { GET } from '.'
+import { readable } from 'svelte/store'
+
+export type Country = {
+  name: string
+}
+
+let hasLoaded = false
+
+export const countries = readable<Country[]>([], function start(set) {
+  if (!hasLoaded) {
+    GET<Country[]>('config/countries').then((values: Country[]) => {
+      set(values)
+      hasLoaded = true
+    })
+  }
+})

--- a/src/pages/settings/personal.svelte
+++ b/src/pages/settings/personal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 import user, { attachUserPhoto, updateUser } from '../../authn/user'
-import { Breadcrumb, FileDropArea, RadioOptions } from 'components'
+import { Breadcrumb, FileDropArea, RadioOptions, SearchableSelect } from 'components'
 import { upload } from 'data'
+import { countries, Country } from 'data/countries'
 import { policies } from 'data/policies'
 import { assertEmailAddress } from '../../validation/assertions'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -18,10 +19,13 @@ let uploading = false
 let notification_email = $user.email_override ? NOTIFICATION_OPTION_CUSTOM : NOTIFICATION_OPTION_DEFAULT
 let email_override = $user.email_override || ''
 let country = $user.country || ''
+let countryOptions = {}
 let croppie: Croppie
 let croppieContainer: HTMLDivElement
 let breadcrumbLinks = [{ name: 'Personal Settings', url: SETTINGS_PERSONAL }]
 metatags.title = formatPageTitle('Personal Settings')
+
+$: $countries.forEach((country: Country) => (countryOptions[country.name] = country.name))
 
 $: notificationOptions = [
   { label: 'Default email: ' + $user.email, value: NOTIFICATION_OPTION_DEFAULT },
@@ -38,7 +42,8 @@ const updateCustomEmail = async () => {
   setNotice('Your notification email has been saved')
 }
 
-const updateCountry = async () => {
+const updateCountry = async (event: CustomEvent) => {
+  country = event.detail
   if (isCountryValid(country)) {
     await updateUser({
       email_override,
@@ -46,7 +51,7 @@ const updateCountry = async () => {
     })
     setNotice('Your country has been saved')
   } else {
-    setNotice('Please enter a country')
+    setNotice('Please select a country from the list')
   }
 }
 
@@ -104,7 +109,7 @@ async function onUpload() {
   }
 }
 
-const isCountryValid = (country: string) => !!country
+const isCountryValid = (countryName: string) => $countries.some((country) => country.name === countryName)
 </script>
 
 <style>
@@ -136,7 +141,7 @@ p {
 
   <p>
     <span class="header">Primary Location<span class="required">*</span></span>
-    <TextField placeholder={'Enter country'} bind:value={country} on:blur={updateCountry} />
+    <SearchableSelect choice={country} options={countryOptions} placeholder="Enter country" on:check={updateCountry} />
   </p>
 
   {#if 0}


### PR DESCRIPTION
### Added
- Add a `countries` svelte store, populated asynchronously when first used

### Changed
- Change "Personal Settings" page to be a searchable-select of a list of countries

---

We'll probably want to extract this to a `<CountrySelector ... />` or something like that if we end up using this in multiple places (such as on the DependentForm). There were just enough details involved that I wouldn't want them replicated throughout our codebase.