### PR TITLE
remove auto-width from app drawer

### DIFF
--- a/src/components/AppDrawer.svelte
+++ b/src/components/AppDrawer.svelte
@@ -23,7 +23,7 @@ const logoClickHandler = () => $goto(ROOT)
 }
 </style>
 
-<Drawer modal hideForPhonesOnly {toggle} {menuItems} title="Covered" class="auto-width border-white">
+<Drawer modal hideForPhonesOnly {toggle} {menuItems} title="Covered" class="border-white">
   <span class="pointer" on:click={logoClickHandler} slot="header">
     <img class="w-100" src="/logo.svg" alt="Cover" />
   </span>

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -108,7 +108,7 @@ const toggleRoleAndPolicyMenu = () => (menuIsOpen = !menuIsOpen)
 }
 </style>
 
-<Button appendIcon="arrow_drop_down" on:click={toggleRoleAndPolicyMenu}>{buttonText || ''}</Button>
+<Button class="w-100" appendIcon="arrow_drop_down" on:click={toggleRoleAndPolicyMenu}>{buttonText || ''}</Button>
 <div id="role-and-policy-menu-options-container">
   <Menu bind:menuOpen={menuIsOpen} {menuItems} />
 </div>


### PR DESCRIPTION
* resolves the issue where the app drawer resizes with a long team name
* instead it will now show as below (default behavior for a Button)
 
![image](https://user-images.githubusercontent.com/242294/142639547-842af5f6-4e5f-46f4-b865-0b119e680c6d.png)
