### PR TITLE
Update the user store when updating a policy

### DIFF
--- a/src/authn/user.ts
+++ b/src/authn/user.ts
@@ -39,6 +39,19 @@ export type UpdatedUserBody = {
 
 const user = writable<User>({} as User)
 
+// Update a policy in the user store when it has been updated
+export function updateUserPolicyStore(updatedPolicy: Policy): void {
+  user.update((user) => {
+    if (user?.policies?.length > 0 && updatedPolicy?.id) {
+      const idx = user.policies.findIndex((p) => p.id === updatedPolicy.id)
+      if (idx !== -1) {
+        user.policies[idx] = updatedPolicy
+      }
+    }
+    return user
+  })
+}
+
 export default user
 
 export async function loadUser(forceReload?: boolean): Promise<void> {

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -1,4 +1,4 @@
-import { loadUser } from '../authn/user'
+import { loadUser, updateUserPolicyStore } from '../authn/user'
 import { derived, get, writable } from 'svelte/store'
 import type { Claim } from './claims'
 import { CREATE, GET, UPDATE } from './index'
@@ -77,11 +77,8 @@ const updatePoliciesStore = (changedPolicy: Policy) => {
 export async function updatePolicy(id: string, policyData: UpdatePolicyRequestBody): Promise<void> {
   const updatedPolicy = await UPDATE<Policy>(`policies/${id}`, policyData)
 
-  policies.update((currPolicies) => {
-    const i = currPolicies.findIndex((pol) => pol.id === id)
-    currPolicies[i] = updatedPolicy
-    return currPolicies
-  })
+  updatePoliciesStore(updatedPolicy)
+  updateUserPolicyStore(updatedPolicy)
 }
 
 /**


### PR DESCRIPTION
* This resolves an issue where a policy name in the sidebar is not updated when a policy name change occurs