### PR TITLE
Fix umbrella icon in menu

### DIFF
--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -38,7 +38,7 @@ $: menuItems = [
   {
     url: routes.ITEMS,
     urlPattern: /(\/items$)|(\/items\/)/,
-    icon: 'umbrella',
+    icon: 'beach_access',
     label: 'Items',
     hide: inAdminRole,
   },


### PR DESCRIPTION
### Fixed
- Use an open umbrella icon for the "Items" nav menu entry