### PR TITLE
don't allow customer to change household ID

### DIFF
--- a/src/components/NoHouseholdIdModal.svelte
+++ b/src/components/NoHouseholdIdModal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+import { COVER_EMAIL } from './const'
 import type { UpdatePolicyRequestBody } from 'data/policies'
-import { POLICY_NEW_TEAM } from 'helpers/routes'
-import { Dialog, setNotice, TextField } from '@silintl/ui-components'
+import { COVER_EMAIL_HREF, POLICY_NEW_TEAM } from 'helpers/routes'
+import { Dialog } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
 export let open = false
@@ -9,28 +10,15 @@ export let open = false
 const policyData: UpdatePolicyRequestBody = {}
 
 let title = 'Missing information'
-let householdId = ''
 let hasClosed: boolean = false
 
-const buttons: Dialog.AlertButton[] = [
-  { label: 'Go Back', action: 'cancel', class: 'mdc-dialog__button' },
-  { label: 'Submit', action: 'submit', class: 'mdc-button--raised' },
-]
+const buttons: Dialog.AlertButton[] = [{ label: 'Go Back', action: 'cancel', class: 'mdc-dialog__button' }]
 
 const dispatch = createEventDispatcher<{ closed: { choice: string; data?: UpdatePolicyRequestBody } }>()
 
 const handleDialog = (event: CustomEvent) => {
   const choice: string = event.detail || ''
-  if (choice === 'submit') {
-    householdId = householdId.replaceAll(' ', '')
-    if (isIdValid(householdId)) {
-      policyData.household_id = householdId
-      dispatch('closed', { choice, data: policyData })
-      hasClosed = true
-    } else {
-      setNotice('Please enter a valid Household ID')
-    }
-  } else if (choice === 'cancel') {
+  if (choice === 'cancel') {
     dispatch('closed', { choice })
     hasClosed = true
     // prevents emiiting a second 'closed' event
@@ -42,19 +30,16 @@ const handleDialog = (event: CustomEvent) => {
 const isIdValid = (id: string): boolean => /^[0-9]+$/.test(id)
 </script>
 
-<style>
-.required {
-  color: var(--mdc-theme-status-error);
-}
-</style>
-
 <Dialog.Alert {open} {buttons} defaultAction="cancel" {title} on:chosen={handleDialog} on:closed={handleDialog}>
-  <p>A household ID is required before getting coverage.</p>
+  <p>
+    A household ID is required before getting coverage. Please contact <a
+      class="mdc-theme--primary"
+      href={COVER_EMAIL_HREF}>{COVER_EMAIL}</a
+    > to add your household ID.
+  </p>
   <p>
     If you'd like to pay with a cost center, consider creating a <a class="mdc-theme--primary" href={POLICY_NEW_TEAM}
       >Team Policy</a
     >.
   </p>
-  <span class="header">Household ID<span class="required">*</span></span>
-  <TextField bind:value={householdId} /></Dialog.Alert
->
+</Dialog.Alert>

--- a/src/components/NoHouseholdIdModal.svelte
+++ b/src/components/NoHouseholdIdModal.svelte
@@ -7,8 +7,6 @@ import { createEventDispatcher } from 'svelte'
 
 export let open = false
 
-const policyData: UpdatePolicyRequestBody = {}
-
 let title = 'Missing information'
 let hasClosed: boolean = false
 
@@ -26,8 +24,6 @@ const handleDialog = (event: CustomEvent) => {
     dispatch('closed', { choice })
   }
 }
-
-const isIdValid = (id: string): boolean => /^[0-9]+$/.test(id)
 </script>
 
 <Dialog.Alert {open} {buttons} defaultAction="cancel" {title} on:chosen={handleDialog} on:closed={handleDialog}>

--- a/src/components/const.ts
+++ b/src/components/const.ts
@@ -2,3 +2,4 @@ export const sec = 1000
 export const min = sec * 60
 export const hour = min * 60
 export const day = hour * 24
+export const COVER_EMAIL = 'cover@sil.org'

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -45,3 +45,5 @@ export const householdSettingsNewDependent = (policyId: string) => `/policies/${
 
 export const TERMS_OF_SERVICE = '/terms'
 export const PRIVACY_POLICY = '/privacy'
+
+export const COVER_EMAIL_HREF = 'mailto:cover@sil.org'

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -5,7 +5,7 @@ import { formatDate } from 'components/dates'
 import { isLoadingById, loading } from 'components/progress'
 import { formatFriendlyDate } from 'helpers/date'
 import { formatMoney } from 'helpers/money'
-import { customerClaimDetails, itemDetails } from 'helpers/routes'
+import { customerClaimDetails, itemDetails, settingsPolicy } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { metatags } from '@roxi/routify'
 import { Datatable, Page } from '@silintl/ui-components'
@@ -79,6 +79,10 @@ th {
       <td>{formatFriendlyDate(policy.updated_at)}</td>
     </tr>
   </table>
+
+  <div class="mt-1">
+    <a class="mdc-theme--primary mt-2" href={settingsPolicy(policyId)}>Policy Settings</a>
+  </div>
 
   <h4>Members</h4>
   <Datatable>

--- a/src/pages/policies/[policyId]/settings.svelte
+++ b/src/pages/policies/[policyId]/settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import user from '../../../authn/user'
+import user, { isAdmin } from '../../../authn/user'
 import { throwError } from '../../../error'
 import { Breadcrumb, Description, SearchableSelect, Modal, DependentForm } from 'components'
 import type { DependentFormData } from 'components/forms/DependentForm.svelte'
@@ -13,7 +13,7 @@ import {
 import { entityCodes, loadEntityCodes } from 'data/entityCodes'
 import { policies, updatePolicy, Policy, PolicyType, loadPolicy } from 'data/policies'
 import { invitePolicyMember, loadMembersOfPolicy, PolicyMember, selectedPolicyMembers } from 'data/policy-members'
-import { selectedPolicyId } from 'data/role-policy-selection'
+import { roleSelection, selectedPolicyId } from 'data/role-policy-selection'
 import { settingsPolicy, SETTINGS_PERSONAL } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
@@ -235,7 +235,7 @@ p {
 
 <Page>
   <Breadcrumb links={breadcrumbLinks} />
-  {#if policy.type === PolicyType.Household}
+  {#if policy.type === PolicyType.Household && isAdmin($roleSelection)}
     <p>
       <span class="header">Household ID<span class="required">*</span></span>
       <TextField placeholder={'1234567'} bind:value={householdId} on:blur={updateHouseholdId} />

--- a/src/pages/policies/[policyId]/settings.svelte
+++ b/src/pages/policies/[policyId]/settings.svelte
@@ -14,7 +14,7 @@ import { entityCodes, loadEntityCodes } from 'data/entityCodes'
 import { policies, updatePolicy, Policy, PolicyType, loadPolicy } from 'data/policies'
 import { invitePolicyMember, loadMembersOfPolicy, PolicyMember, selectedPolicyMembers } from 'data/policy-members'
 import { roleSelection, selectedPolicyId } from 'data/role-policy-selection'
-import { settingsPolicy, SETTINGS_PERSONAL } from 'helpers/routes'
+import { POLICIES, policyDetails, settingsPolicy, SETTINGS_PERSONAL } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Button, TextField, IconButton, Page, setNotice, Tooltip } from '@silintl/ui-components'
@@ -38,7 +38,14 @@ let modalData: PolicyDependent
 let showAddDependentModal = false
 let modalTitle = 'Add Person'
 
-let breadcrumbLinks = [{ name: 'Policy Settings', url: settingsPolicy(policyId) }]
+$: breadcrumbLinks = isAdmin($roleSelection)
+  ? [
+      { name: 'Policies', url: POLICIES },
+      { name: policy.name, url: policyDetails(policyId) },
+      { name: 'Policy Settings', url: settingsPolicy(policyId) },
+    ]
+  : [{ name: 'Policy Settings', url: settingsPolicy(policyId) }]
+
 metatags.title = formatPageTitle('Policy Settings')
 
 $: if (policyId) {

--- a/src/pages/privacy.svelte
+++ b/src/pages/privacy.svelte
@@ -1,4 +1,6 @@
 <script>
+import { COVER_EMAIL } from 'components/const'
+import { COVER_EMAIL_HREF } from 'helpers/routes'
 import { Page } from '@silintl/ui-components'
 </script>
 
@@ -205,9 +207,9 @@ td > p {
   </table>
   <h2 id="access-or-removal">How you can access or request removal of information about you</h2>
   <p>
-    You may send an email to <a href="mailto:cover@sil.org">cover@sil.org</a> to request access to the information we have
-    about you, or to request that we delete the information we have about you. In some cases, removal of your information
-    may not be possible due to financial obligations or the service in general.
+    You may send an email to <a href={COVER_EMAIL_HREF}>{COVER_EMAIL}</a> to request access to the information we have about
+    you, or to request that we delete the information we have about you. In some cases, removal of your information may not
+    be possible due to financial obligations or the service in general.
   </p>
   <h2 id="cookies-and-tracking">How we use cookies and tracking</h2>
   <p>
@@ -269,7 +271,7 @@ td > p {
   <p>
     We may also reach out to you personally if we notice you have encountered an error with the system or if we&#39;d
     like to ask for your participation in trying new features or giving us feedback about Cover. These emails will be
-    sent from <a href="mailto:cover@sil.org">cover@sil.org</a>.
+    sent from <a href={COVER_EMAIL_HREF}>{COVER_EMAIL}</a>.
   </p>
   <h2 id="changes-to-our-privacy-policy">Changes to our Privacy Policy</h2>
   <p>
@@ -280,6 +282,6 @@ td > p {
   </p>
   <h2 id="contacting-us">Contacting us</h2>
   <p>
-    You may contact us at any time for any reason by emailing <a href="mailto:cover@sil.org">cover@sil.org</a>.
+    You may contact us at any time for any reason by emailing <a href={COVER_EMAIL_HREF}>{COVER_EMAIL}</a>.
   </p>
 </Page>

--- a/src/pages/terms.svelte
+++ b/src/pages/terms.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { COVER_EMAIL } from 'components/const'
+import { COVER_EMAIL_HREF } from 'helpers/routes'
 import { Page } from '@silintl/ui-components'
 </script>
 
@@ -28,7 +30,7 @@ td > p {
     liability for the Cover service.
   </p>
   <p>
-    You may contact us at any time by emailing <a href="mailto:cover@sil.org">cover@sil.org</a>.
+    You may contact us at any time by emailing <a href={COVER_EMAIL_HREF}>{COVER_EMAIL}</a>.
   </p>
 
   <h2>Table of Contents</h2>
@@ -388,7 +390,7 @@ td > p {
     With all that scary stuff said, we do care deeply about you, your data, and any information we store about you. As a
     team, we care deeply about security and take every reasonable effort to ensure the service is stable, secure, and
     available when you need it. If you believe we are falling short in any of these areas, please let us know:
-    <span><a href="mailto:cover@sil.org">cover@sil.org</a></span>.
+    <span><a href={COVER_EMAIL_HREF}>{COVER_EMAIL}</a></span>.
   </p>
   <h2 id="limitation-of-liability">Limitation of Liability</h2>
   <p>


### PR DESCRIPTION
- remove householdId form noHouseholdIdModal
- add message to contact cover@sil.org for householdId changes
- hide householdId field on 'policy/settings' view for customer
- add link to 'policy/settings' on policy view
- add a const and route for cover.sil.or
![ezgif-2-a1d99ef91226](https://user-images.githubusercontent.com/70765247/144920108-92f94f5a-69fa-4d48-8554-f5fe9fa535a4.gif)
g

![image](https://user-images.githubusercontent.com/70765247/144920381-2fb2a7b6-88a9-40a2-be1a-a589a22ab76b.png)
