### PR TITLE
new-claim show save for later and disable buttons

### DIFF
--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -4,7 +4,7 @@ import { PayoutOption, ClaimItem, ClaimStatus, ClaimFilePurpose } from 'data/cla
 export const DEDUCTIBLE = 0.05
 export const LOSS_REASON_EVACUATION = 'Evacuation'
 
-export const isFairMarketValueNeeded = (isRepairable?: boolean | null, payoutOption?: string): boolean => {
+export const isFairMarketValueNeeded = (isRepairable?: boolean, payoutOption?: string): boolean => {
   return isRepairable || payoutOption === PayoutOption.FMV
 }
 

--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -4,7 +4,7 @@ import { PayoutOption, ClaimItem, ClaimStatus, ClaimFilePurpose } from 'data/cla
 export const DEDUCTIBLE = 0.05
 export const LOSS_REASON_EVACUATION = 'Evacuation'
 
-export const isFairMarketValueNeeded = (isRepairable?: boolean, payoutOption?: string): boolean => {
+export const isFairMarketValueNeeded = (isRepairable?: boolean | null, payoutOption?: string): boolean => {
   return isRepairable || payoutOption === PayoutOption.FMV
 }
 
@@ -31,14 +31,14 @@ export const isRepairCostTooHigh = (repairEstimateUSD?: number, fairMarketValueU
 }
 
 export const isUnrepairableOrTooExpensive = (
-  isRepairable?: boolean,
+  isRepairable?: boolean | null,
   repairCostIsTooHigh?: boolean
 ): boolean | undefined => {
   if (isRepairable === false) {
     return true
   }
 
-  if (isRepairable === undefined || repairCostIsTooHigh === undefined) {
+  if ([null, undefined].includes(isRepairable) || repairCostIsTooHigh === undefined) {
     return undefined
   }
 

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -95,6 +95,13 @@ $: !isRepairable && unSetRepairEstimate()
 $: needsEvidence = !unrepairableOrTooExpensive || payoutOption === PayoutOption.FMV
 $: needsPayoutOption = !(isRepairable || isEvacuation) || repairCostIsTooHigh
 $: canContinueToEvidence = (!!repairEstimateUSD && !!fairMarketValueUSD) || (!!fairMarketValueUSD && !isRepairable)
+$: saveButtonIsDisable = !situationDescription || !lossReason || !repairableSelection
+$: submitIsDisabled =
+  saveButtonIsDisable ||
+  (potentiallyRepairable && !repairableSelection) ||
+  (isRepairable && (!repairEstimateUSD || !fairMarketValueUSD)) ||
+  (needsPayoutOption && !payoutOption) ||
+  (payoutOption === PayoutOption.Replacement && !replaceEstimateUSD)
 
 // Calculate dynamic options for radio-button prompts.
 $: lossReasonOptions = $claimIncidentTypes.map(({ name, description }) => ({ label: name, value: name, description }))
@@ -146,8 +153,6 @@ const onSubmitClaim = (event: Event) => {
 
 const onSaveForLater = (event: Event) => {
   event.preventDefault()
-  assertHas(lossReason, 'Please select a reason for loss or damage')
-  assertHas(situationDescription, 'Please describe the situation')
   dispatch('save-for-later', getFormData())
 }
 
@@ -279,15 +284,11 @@ const unSetReplaceEstimate = () => {
     <!--TODO: add evacuation amount when items is done (covered_value*(2/3))-->
     <p>
       {#if needsEvidence}
-        {#if canContinueToEvidence}
-          <Button on:click={onSaveForLater} outlined>Save For Later</Button>
-          <Button on:click={onSaveForLater} raised>Continue</Button>
-        {:else}
-          <Button on:click={onSaveForLater} outlined>Save For Later</Button>
-        {/if}
+        <Button on:click={onSaveForLater} disabled={saveButtonIsDisable} outlined>Save For Later</Button>
+        <Button on:click={onSaveForLater} disabled={!canContinueToEvidence} raised>Continue</Button>
       {:else}
-        <Button on:click={onSaveForLater} outlined>Save For Later</Button>
-        <Button on:click={onSubmitClaim} raised>Submit Claim</Button>
+        <Button on:click={onSaveForLater} disabled={saveButtonIsDisable} outlined>Save For Later</Button>
+        <Button on:click={onSubmitClaim} disabled={submitIsDisabled} raised>Submit Claim</Button>
       {/if}
     </p>
   </Form>

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -283,11 +283,10 @@ const unSetReplaceEstimate = () => {
     {/if}
     <!--TODO: add evacuation amount when items is done (covered_value*(2/3))-->
     <p>
+      <Button on:click={onSaveForLater} disabled={saveButtonIsDisabled} outlined>Save For Later</Button>
       {#if needsEvidence}
-        <Button on:click={onSaveForLater} disabled={saveButtonIsDisabled} outlined>Save For Later</Button>
         <Button on:click={onSaveForLater} disabled={!canContinueToEvidence} raised>Continue</Button>
       {:else}
-        <Button on:click={onSaveForLater} disabled={saveButtonIsDisabled} outlined>Save For Later</Button>
         <Button on:click={onSubmitClaim} disabled={submitIsDisabled} raised>Submit Claim</Button>
       {/if}
     </p>

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -49,7 +49,7 @@ const payoutOptions = [
 let lostDate = todayDateString
 let lossReason: string
 let situationDescription = ''
-let isRepairable: boolean | undefined
+let isRepairable: boolean | null | undefined
 let payoutOption: PayoutOption | undefined
 
 // Set default derived (or intermediate) values.
@@ -95,7 +95,7 @@ $: !isRepairable && unSetRepairEstimate()
 $: needsEvidence = !unrepairableOrTooExpensive || payoutOption === PayoutOption.FMV
 $: needsPayoutOption = !(isRepairable || isEvacuation) || repairCostIsTooHigh
 $: canContinueToEvidence = (!!repairEstimateUSD && !!fairMarketValueUSD) || (!!fairMarketValueUSD && !isRepairable)
-$: saveButtonIsDisable = !situationDescription || !lossReason || !repairableSelection
+$: saveButtonIsDisable = !situationDescription || !lossReason
 $: submitIsDisabled =
   saveButtonIsDisable ||
   (potentiallyRepairable && !repairableSelection) ||
@@ -114,7 +114,7 @@ const calculateIsRepairable = (potentiallyRepairable: boolean, repairableSelecti
     return false
   }
   if (!repairableSelection) {
-    return undefined
+    return null
   }
   return repairableSelection === 'repairable'
 }
@@ -180,7 +180,7 @@ const setInitialValues = (claim: Claim, claimItem: ClaimItem) => {
   }
   lossReason = claim.incident_type || lossReason
   situationDescription = claim.incident_description || situationDescription
-  if (claimItem.is_repairable !== undefined) {
+  if (claimItem.is_repairable !== null && claimItem.is_repairable !== undefined) {
     repairableSelection = claimItem.is_repairable ? 'repairable' : 'not_repairable'
   }
 

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -146,7 +146,8 @@ const onSubmitClaim = (event: Event) => {
 
 const onSaveForLater = (event: Event) => {
   event.preventDefault()
-  validateForm()
+  assertHas(lossReason, 'Please select a reason for loss or damage')
+  assertHas(situationDescription, 'Please describe the situation')
   dispatch('save-for-later', getFormData())
 }
 
@@ -279,6 +280,7 @@ const unSetReplaceEstimate = () => {
     <p>
       {#if needsEvidence}
         {#if canContinueToEvidence}
+          <Button on:click={onSaveForLater} outlined>Save For Later</Button>
           <Button on:click={onSaveForLater} raised>Continue</Button>
         {:else}
           <Button on:click={onSaveForLater} outlined>Save For Later</Button>

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -86,7 +86,7 @@ $: repairCostIsTooHigh = isRepairCostTooHigh(repairEstimateUSD, fairMarketValueU
 $: unrepairableOrTooExpensive = isUnrepairableOrTooExpensive(isRepairable, repairCostIsTooHigh)
 $: shouldAskReplaceOrFMV = !isEvacuation && unrepairableOrTooExpensive === true
 $: shouldAskIfRepairable = !!(potentiallyRepairable && lossReason)
-$: shouldAskForFMV = isFairMarketValueNeeded(isRepairable, payoutOption)
+$: shouldAskForFMV = isRepairable !== null && isFairMarketValueNeeded(isRepairable, payoutOption)
 $: payoutOption !== PayoutOption.Replacement && unSetReplaceEstimate()
 $: !shouldAskReplaceOrFMV && unSetPayoutOption()
 $: !shouldAskIfRepairable && unSetRepairableSelection()
@@ -95,9 +95,9 @@ $: !isRepairable && unSetRepairEstimate()
 $: needsEvidence = !unrepairableOrTooExpensive || payoutOption === PayoutOption.FMV
 $: needsPayoutOption = !(isRepairable || isEvacuation) || repairCostIsTooHigh
 $: canContinueToEvidence = (!!repairEstimateUSD && !!fairMarketValueUSD) || (!!fairMarketValueUSD && !isRepairable)
-$: saveButtonIsDisable = !situationDescription || !lossReason
+$: saveButtonIsDisabled = !situationDescription || !lossReason
 $: submitIsDisabled =
-  saveButtonIsDisable ||
+  saveButtonIsDisabled ||
   (potentiallyRepairable && !repairableSelection) ||
   (isRepairable && (!repairEstimateUSD || !fairMarketValueUSD)) ||
   (needsPayoutOption && !payoutOption) ||
@@ -284,10 +284,10 @@ const unSetReplaceEstimate = () => {
     <!--TODO: add evacuation amount when items is done (covered_value*(2/3))-->
     <p>
       {#if needsEvidence}
-        <Button on:click={onSaveForLater} disabled={saveButtonIsDisable} outlined>Save For Later</Button>
+        <Button on:click={onSaveForLater} disabled={saveButtonIsDisabled} outlined>Save For Later</Button>
         <Button on:click={onSaveForLater} disabled={!canContinueToEvidence} raised>Continue</Button>
       {:else}
-        <Button on:click={onSaveForLater} disabled={saveButtonIsDisable} outlined>Save For Later</Button>
+        <Button on:click={onSaveForLater} disabled={saveButtonIsDisabled} outlined>Save For Later</Button>
         <Button on:click={onSubmitClaim} disabled={submitIsDisabled} raised>Submit Claim</Button>
       {/if}
     </p>

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -299,7 +299,7 @@ const isFileUploadedByPurpose = (purpose: ClaimFilePurpose, files: ClaimFile[]):
       </p>
       <div>
         <h2>Resolution</h2>
-        <h3>{payoutOption}</h3>
+        <h3>{payoutOption || 'No payout option selected'}</h3>
         {#if payoutOption == PayoutOption.Replacement}
           <p>Payout is the item’s covered value or replacement cost, whichever is less, minus a 5% deductible.</p>
         {/if}


### PR DESCRIPTION
- show "save for later" alongside "continue"
- disable buttons when missing fields
- allow saving a draft claim without all the fields