### PR TITLE
Fix claims page

### DIFF
--- a/src/components/ClaimsTable.svelte
+++ b/src/components/ClaimsTable.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import { Claim } from '../data/claims'
+import { formatFriendlyDate } from 'helpers/date'
+import { formatMoney } from 'helpers/money'
+import { customerClaimDetails } from 'helpers/routes'
+import { Datatable } from '@silintl/ui-components'
+
+export let claims = [] as Claim[]
+export let policyId: string
+export let title = ''
+</script>
+
+{#if title}
+  <h3>{title}</h3>
+{/if}
+<Datatable>
+  <Datatable.Header>
+    <Datatable.Header.Item>Reference #</Datatable.Header.Item>
+    <Datatable.Header.Item>Incident Date</Datatable.Header.Item>
+    <Datatable.Header.Item>Status</Datatable.Header.Item>
+    <Datatable.Header.Item>Repairable</Datatable.Header.Item>
+    <Datatable.Header.Item>Payout Option</Datatable.Header.Item>
+    <Datatable.Header.Item numeric>Repair</Datatable.Header.Item>
+    <Datatable.Header.Item numeric>Replacement</Datatable.Header.Item>
+    <Datatable.Header.Item numeric>FMV</Datatable.Header.Item>
+  </Datatable.Header>
+  <Datatable.Data>
+    {#each claims as claim (claim.id)}
+      {#each claim.claim_items as claimItem (claimItem.id)}
+        <Datatable.Data.Row>
+          <Datatable.Data.Row.Item>
+            <a href={customerClaimDetails(policyId, claim.id)}>{claim.reference_number || ''}</a>
+            ({claim.status})
+          </Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{formatFriendlyDate(claim.incident_date)}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{claimItem.status || ''}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{claimItem.is_repairable ? 'Yes' : 'No'}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{claimItem.payout_option || ''}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item numeric>{formatMoney(claimItem.repair_estimate)}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item numeric>{formatMoney(claimItem.replace_estimate)}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item numeric>{formatMoney(claimItem.fmv)}</Datatable.Data.Row.Item>
+        </Datatable.Data.Row>
+      {:else}
+        <Datatable.Data.Row>
+          <Datatable.Data.Row.Item>
+            <a href={customerClaimDetails(policyId, claim.id)}>{claim.reference_number || ''}</a>
+            ({claim.status})
+          </Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{formatFriendlyDate(claim.incident_date)}</Datatable.Data.Row.Item>
+        </Datatable.Data.Row>
+      {/each}
+    {:else}
+      <Datatable.Data.Row>
+        <Datatable.Data.Row.Item colspan={8}>
+          <i>None</i>
+        </Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+    {/each}
+  </Datatable.Data>
+</Datatable>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ import ClaimActions from './ClaimActions.svelte'
 import ClaimCard from './ClaimCard.svelte'
 import ClaimCards from './ClaimCards.svelte'
 import ClaimForm from './forms/ClaimForm.svelte'
+import ClaimsTable from './ClaimsTable.svelte'
 import ConvertCurrencyLink from './ConvertCurrencyLink.svelte'
 import CountrySelector from './CountrySelector.svelte'
 import DateInput from './DateInput.svelte'
@@ -38,6 +39,7 @@ export {
   Breadcrumb,
   ClaimActions,
   ClaimForm,
+  ClaimsTable,
   ConvertCurrencyLink,
   CountrySelector,
   DateInput,

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+import { ClaimsTable } from 'components'
 import { getNameOfPolicy, loadPolicy, Policy, PolicyType, selectedPolicy } from 'data/policies'
 import { loadItems, selectedPolicyItems } from 'data/items'
 import { formatDate } from 'components/dates'
 import { isLoadingById, loading } from 'components/progress'
 import { formatFriendlyDate } from 'helpers/date'
 import { formatMoney } from 'helpers/money'
-import { customerClaimDetails, itemDetails, settingsPolicy } from 'helpers/routes'
+import { itemDetails, settingsPolicy } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { metatags } from '@roxi/routify'
 import { Datatable, Page } from '@silintl/ui-components'
@@ -139,50 +140,6 @@ th {
   {#if $loading && isLoadingById(`policies/${policyId}/claims`)}
     Loading claims...
   {:else}
-    <Datatable>
-      <Datatable.Header>
-        <Datatable.Header.Item>Reference #</Datatable.Header.Item>
-        <Datatable.Header.Item>Incident Date</Datatable.Header.Item>
-        <Datatable.Header.Item>Status</Datatable.Header.Item>
-        <Datatable.Header.Item>Repairable</Datatable.Header.Item>
-        <Datatable.Header.Item>Payout Option</Datatable.Header.Item>
-        <Datatable.Header.Item numeric>Repair</Datatable.Header.Item>
-        <Datatable.Header.Item numeric>Replacement</Datatable.Header.Item>
-        <Datatable.Header.Item numeric>FMV</Datatable.Header.Item>
-      </Datatable.Header>
-      <Datatable.Data>
-        {#each claims as claim (claim.id)}
-          {#each claim.claim_items as claimItem (claimItem.id)}
-            <Datatable.Data.Row>
-              <Datatable.Data.Row.Item>
-                <a href={customerClaimDetails(policyId, claim.id)}>{claim.reference_number || ''}</a>
-                ({claim.status})
-              </Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item>{formatFriendlyDate(claim.incident_date)}</Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item>{claimItem.status || ''}</Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item>{claimItem.is_repairable ? 'Yes' : 'No'}</Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item>{claimItem.payout_option || ''}</Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item numeric>{formatMoney(claimItem.repair_estimate)}</Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item numeric>{formatMoney(claimItem.replace_estimate)}</Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item numeric>{formatMoney(claimItem.fmv)}</Datatable.Data.Row.Item>
-            </Datatable.Data.Row>
-          {:else}
-            <Datatable.Data.Row>
-              <Datatable.Data.Row.Item>
-                <a href={customerClaimDetails(policyId, claim.id)}>{claim.reference_number || ''}</a>
-                ({claim.status})
-              </Datatable.Data.Row.Item>
-              <Datatable.Data.Row.Item>{formatFriendlyDate(claim.incident_date)}</Datatable.Data.Row.Item>
-            </Datatable.Data.Row>
-          {/each}
-        {:else}
-          <Datatable.Data.Row>
-            <Datatable.Data.Row.Item colspan={8}>
-              <i>None</i>
-            </Datatable.Data.Row.Item>
-          </Datatable.Data.Row>
-        {/each}
-      </Datatable.Data>
-    </Datatable>
+    <ClaimsTable {claims} {policyId} />
   {/if}
 </Page>

--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { UserAppRole } from '../../../authn/user'
-import { ClaimCards, Row, Breadcrumb } from 'components'
+import { Breadcrumb, ClaimCards, ClaimsTable, Row } from 'components'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
 import { loadItems } from 'data/items'
 import { getNameOfPolicy, selectedPolicy } from 'data/policies'
@@ -44,6 +44,7 @@ const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(ev
   <Row cols={'12'}>
     {#if $selectedPolicyClaims.length}
       <ClaimCards {isAdmin} claims={$selectedPolicyClaims} on:goto-claim={onGotoClaim} />
+      <ClaimsTable claims={$selectedPolicyClaims} {policyId} />
     {:else}
       <p class="m-0-auto text-align-center">You don't have any claims in this policy</p>
       <p class="m-0-auto text-align-center">


### PR DESCRIPTION
### Fixed
- Add (missing) table of claims to the claims page

---

Side note: We still seem to have an off-by-one error in the output of both `formatDate()` and `formatFriendlyDate()`, and I haven't had time (and probably won't have time) to fix that myself in the near future, if one of you two would be available to handle that.