### PR TITLE
add maxlength to text inputs

### DIFF
--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { UserAppRole } from '../authn/user'
-import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
+import { MAX_TEXT_AREA_LENGTH as maxlength } from 'components/const'
 import {
   Claim,
   ClaimStatus,

--- a/src/components/ClaimActions.svelte
+++ b/src/components/ClaimActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { UserAppRole } from '../authn/user'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import {
   Claim,
   ClaimStatus,
@@ -97,7 +98,7 @@ const onDeny = () => dispatch('deny', message)
   {#if statusesAvaitingAdmin.includes(status)}
     <div class="container">
       <div class="text-input">
-        <TextField class="w-100" label="Send a message" bind:value={message} />
+        <TextField {maxlength} class="w-100" label="Send a message" bind:value={message} />
         <Description>A message is required to deny or ask for changes.</Description>
       </div>
       <div class="left-buttons">

--- a/src/components/MoneyInput.svelte
+++ b/src/components/MoneyInput.svelte
@@ -7,7 +7,7 @@ import { onMount } from 'svelte'
 export let label = ''
 export let value = ''
 export let placeholder = ''
-export let maxlength: number = 524288 /* default */
+export let maxlength: number = 2048 /* default */
 export let autofocus = false
 export let disabled = false
 export let required = false
@@ -67,6 +67,7 @@ const focus = (node: any) => autofocus && node.focus()
     {maxlength}
     {disabled}
     {placeholder}
+    {required}
   />
   <span class="mdc-notched-outline">
     <span class="mdc-notched-outline__leading" style="width:35px;" />
@@ -78,3 +79,6 @@ const focus = (node: any) => autofocus && node.focus()
     <span class="mdc-notched-outline__trailing" />
   </span>
 </label>
+{#if required && !value}
+  <div class="required">*Required</div>
+{/if}

--- a/src/components/MoneyInput.svelte
+++ b/src/components/MoneyInput.svelte
@@ -7,7 +7,7 @@ import { onMount } from 'svelte'
 export let label = ''
 export let value = ''
 export let placeholder = ''
-export let maxlength: number = 2048 /* default */
+export let maxlength: number = 255/* default */
 export let autofocus = false
 export let disabled = false
 export let required = false

--- a/src/components/MoneyInput.svelte
+++ b/src/components/MoneyInput.svelte
@@ -10,6 +10,7 @@ export let placeholder = ''
 export let maxlength: number = 524288 /* default */
 export let autofocus = false
 export let disabled = false
+export let required = false
 
 const labelID = generateRandomID('text-label-')
 
@@ -36,12 +37,14 @@ const focus = (node: any) => autofocus && node.focus()
   left: 10px;
 }
 
-.m-l-24px {
-  margin-left: 24px;
-}
-
 .label-width {
   width: 269px;
+}
+.required {
+  color: var(--mdc-required-input, var(--mdc-theme-status-error));
+  font-size: small;
+  margin-left: 1rem;
+  margin-top: 0.2rem;
 }
 </style>
 
@@ -51,12 +54,12 @@ const focus = (node: any) => autofocus && node.focus()
   class:mdc-text-field--disabled={disabled}
   bind:this={element}
 >
-  <i class="material-icons mdc-list-item__graphic money-icon" aria-hidden="true">attach_money</i>
+  <i class="material-icons money-icon" aria-hidden="true">attach_money</i>
   <input
     step="0.01"
     type="number"
     min="0"
-    class="mdc-text-field__input m-l-24px"
+    class="mdc-text-field__input ml-24px"
     aria-labelledby={labelID}
     bind:value
     use:focus

--- a/src/components/SearchableSelect.svelte
+++ b/src/components/SearchableSelect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import { generateRandomID } from '@silintl/ui-components/random'
 import { createEventDispatcher } from 'svelte'
 
@@ -60,6 +61,7 @@ const onChange = () => options[internalChoice] && dispatch('chosen', options[int
 
 <label class="custom-field" style="--field-padding: {padding};">
   <input
+    {maxlength}
     class="fs-14 {$$props.class}"
     style="width: {width}"
     list={randomId}

--- a/src/components/const.ts
+++ b/src/components/const.ts
@@ -3,4 +3,5 @@ export const min = sec * 60
 export const hour = min * 60
 export const day = hour * 24
 export const COVER_EMAIL = 'cover@sil.org'
-export const MAX_INPUT_LENGTH = 2048
+export const MAX_INPUT_LENGTH = 255
+export const MAX_TEXT_AREA_LENGTH = 2048

--- a/src/components/const.ts
+++ b/src/components/const.ts
@@ -3,3 +3,4 @@ export const min = sec * 60
 export const hour = min * 60
 export const day = hour * 24
 export const COVER_EMAIL = 'cover@sil.org'
+export const MAX_INPUT_LENGTH = 4000

--- a/src/components/const.ts
+++ b/src/components/const.ts
@@ -3,4 +3,4 @@ export const min = sec * 60
 export const hour = min * 60
 export const day = hour * 24
 export const COVER_EMAIL = 'cover@sil.org'
-export const MAX_INPUT_LENGTH = 4000
+export const MAX_INPUT_LENGTH = 2048

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -6,7 +6,7 @@ import {
   isUnrepairableOrTooExpensive,
   LOSS_REASON_EVACUATION,
 } from '../../business-rules/claim-payout-amount'
-import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
+import { MAX_TEXT_AREA_LENGTH as maxlength } from 'components/const'
 import { claimIncidentTypes, loadClaimIncidentTypes } from 'data/claim-incident-types'
 import { Claim, ClaimItem, PayoutOption } from 'data/claims'
 import type { PolicyItem } from 'data/items'

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -6,6 +6,7 @@ import {
   isUnrepairableOrTooExpensive,
   LOSS_REASON_EVACUATION,
 } from '../../business-rules/claim-payout-amount'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import { claimIncidentTypes, loadClaimIncidentTypes } from 'data/claim-incident-types'
 import { Claim, ClaimItem, PayoutOption } from 'data/claims'
 import type { PolicyItem } from 'data/items'
@@ -181,9 +182,7 @@ const setInitialValues = (claim: Claim, claimItem: ClaimItem) => {
   lossReason = claim.incident_type || lossReason
   situationDescription = claim.incident_description || situationDescription
   repairableSelection =
-    typeof claimItem.is_repairable !== 'boolean' ||  claimItem.is_repairable
-        ? 'repairable'
-        : 'not_repairable'
+    typeof claimItem.is_repairable !== 'boolean' || claimItem.is_repairable ? 'repairable' : 'not_repairable'
 
   payoutOption = claimItem.payout_option || payoutOption
 
@@ -222,7 +221,7 @@ const unSetReplaceEstimate = () => {
     </p>
     <p>
       <span class="header">What happened?</span>
-      <TextArea label="Describe the situation" bind:value={situationDescription} rows="4" />
+      <TextArea {maxlength} label="Describe the situation" bind:value={situationDescription} rows="4" />
     </p>
     {#if shouldAskIfRepairable}
       <div>

--- a/src/components/forms/DependentForm.svelte
+++ b/src/components/forms/DependentForm.svelte
@@ -14,7 +14,7 @@ export type DependentFormData = {
 <script lang="ts">
 import RadioOptions from '../RadioOptions.svelte'
 import CountrySelector from '../components/CountrySelector.svelte'
-import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
+import { MAX_INPUT_LENGTH as maxlength, MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { PolicyDependent } from 'data/dependents'
 import { assertEmailAddress, assertHas, assertIsLessThan, assertUnique } from '../../validation/assertions'
 import { Button, Form, TextArea, TextField } from '@silintl/ui-components'
@@ -171,7 +171,7 @@ const onChosen = (event: CustomEvent) => (formData.country = event.detail)
       </p>
       <p>
         <TextArea
-          {maxlength}
+          maxlength={MAX_TEXT_AREA_LENGTH}
           class="w-100"
           rows="4"
           placeholder="A personalized message for the person you are inviting"

--- a/src/components/forms/DependentForm.svelte
+++ b/src/components/forms/DependentForm.svelte
@@ -14,6 +14,7 @@ export type DependentFormData = {
 <script lang="ts">
 import RadioOptions from '../RadioOptions.svelte'
 import CountrySelector from '../components/CountrySelector.svelte'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import type { PolicyDependent } from 'data/dependents'
 import { assertEmailAddress, assertHas, assertIsLessThan, assertUnique } from '../../validation/assertions'
 import { Button, Form, TextArea, TextField } from '@silintl/ui-components'
@@ -137,7 +138,7 @@ const onChosen = (event: CustomEvent) => (formData.country = event.detail)
 <div class={$$props.class}>
   <Form on:submit={onSubmit}>
     <p>
-      <TextField label="Person's Name" bind:value={formData.name} class="w-100" autofocus />
+      <TextField {maxlength} label="Person's Name" bind:value={formData.name} class="w-100" autofocus />
     </p>
     {#if isHouseholdPolicy}
       <p>
@@ -156,7 +157,7 @@ const onChosen = (event: CustomEvent) => (formData.country = event.detail)
       </p>
       {#if formData.relationship === 'Child'}
         <p>
-          <TextField label="Child's birth year" bind:value={formData.childBirthYear} class="w-100" />
+          <TextField {maxlength} label="Child's birth year" bind:value={formData.childBirthYear} class="w-100" />
         </p>
       {/if}
     {/if}
@@ -166,10 +167,11 @@ const onChosen = (event: CustomEvent) => (formData.country = event.detail)
     </p>
     {#if formData.permissions === 'can-edit'}
       <p>
-        <TextField label="Email" bind:value={formData.email} class="w-100" />
+        <TextField {maxlength} label="Email" bind:value={formData.email} class="w-100" />
       </p>
       <p>
         <TextArea
+          {maxlength}
           class="w-100"
           rows="4"
           placeholder="A personalized message for the person you are inviting"

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -6,6 +6,7 @@ import MakeAndModelModal from 'MakeAndModelModal.svelte'
 import MoneyInput from '../MoneyInput.svelte'
 import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import SelectAccountablePerson from '../SelectAccountablePerson.svelte'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
 import { ItemCoverageStatus, PolicyItem } from 'data/items'
 import { categories, loadCategories, initialized as catItemsInitialized } from 'data/itemCategories'
@@ -175,23 +176,23 @@ const setInitialValues = (user: User, item: PolicyItem) => {
     />
   </p>
   <p>
-    <TextField label="Short name" bind:value={name} />
+    <TextField {maxlength} label="Short name" bind:value={name} />
     <Description>This label will appear on your statements.</Description>
   </p>
   <p>
-    <TextArea label="Item description" bind:value={itemDescription} rows="4" />
+    <TextArea {maxlength} label="Item description" bind:value={itemDescription} rows="4" />
     <Description>For personal use.</Description>
   </p>
   <p>
-    <TextField label="Unique identifier" bind:value={uniqueIdentifier} />
+    <TextField {maxlength} label="Unique identifier" bind:value={uniqueIdentifier} />
     <Description>Optional. Serial number, IMEI, service tag, VIN</Description>
   </p>
   <p>
-    <TextField label="Make" bind:value={make} />
+    <TextField {maxlength} label="Make" bind:value={make} />
     <Description>Required for mobile items.</Description>
   </p>
   <p>
-    <TextField label="Model" bind:value={model} />
+    <TextField {maxlength} label="Model" bind:value={model} />
     <Description>Required for mobile items.</Description>
   </p>
   <p>

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -6,7 +6,7 @@ import MakeAndModelModal from 'MakeAndModelModal.svelte'
 import MoneyInput from '../MoneyInput.svelte'
 import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import SelectAccountablePerson from '../SelectAccountablePerson.svelte'
-import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
+import { MAX_INPUT_LENGTH as maxlength, MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
 import { ItemCoverageStatus, PolicyItem } from 'data/items'
 import { categories, loadCategories, initialized as catItemsInitialized } from 'data/itemCategories'
@@ -180,7 +180,7 @@ const setInitialValues = (user: User, item: PolicyItem) => {
     <Description>This label will appear on your statements.</Description>
   </p>
   <p>
-    <TextArea {maxlength} label="Item description" bind:value={itemDescription} rows="4" />
+    <TextArea maxlength={MAX_TEXT_AREA_LENGTH} label="Item description" bind:value={itemDescription} rows="4" />
     <Description>For personal use.</Description>
   </p>
   <p>

--- a/src/components/forms/SearchForm.svelte
+++ b/src/components/forms/SearchForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import { debounce } from 'lodash-es'
 import { createEventDispatcher } from 'svelte'
 import { Form, TextField } from '@silintl/ui-components'
@@ -15,5 +16,5 @@ const onKeydown = debounce(() => dispatch('search', searchFieldContents), 500)
 
 <Form>
   Search:
-  <TextField bind:value={searchFieldContents} on:keydown={onKeydown} />
+  <TextField {maxlength} bind:value={searchFieldContents} on:keydown={onKeydown} />
 </Form>

--- a/src/pages/policies/[policyId]/items/[itemId].svelte
+++ b/src/pages/policies/[policyId]/items/[itemId].svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import user, { UserAppRole } from '../../../../authn/user'
 import { Breadcrumb, ItemDeleteModal, ItemDetails } from 'components'
-import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
+import { MAX_TEXT_AREA_LENGTH as maxlength } from 'components/const'
 import { loading } from 'components/progress'
 import { formatDate } from 'components/dates'
 import {

--- a/src/pages/policies/[policyId]/items/[itemId].svelte
+++ b/src/pages/policies/[policyId]/items/[itemId].svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import user, { UserAppRole } from '../../../../authn/user'
 import { Breadcrumb, ItemDeleteModal, ItemDetails } from 'components'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import { loading } from 'components/progress'
 import { formatDate } from 'components/dates'
 import {
@@ -199,6 +200,7 @@ const onReviseItem = () => {
     >
       <p class="message-box">
         <TextArea
+          {maxlength}
           style="width: 300px"
           rows="4"
           placeholder="A message is required to deny coverage or ask for changes"

--- a/src/pages/policies/[policyId]/settings.svelte
+++ b/src/pages/policies/[policyId]/settings.svelte
@@ -2,6 +2,7 @@
 import user, { isAdmin } from '../../../authn/user'
 import { throwError } from '../../../error'
 import { Breadcrumb, Description, SearchableSelect, Modal, DependentForm } from 'components'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import type { DependentFormData } from 'components/forms/DependentForm.svelte'
 import {
   addDependent,
@@ -245,14 +246,14 @@ p {
   {#if policy.type === PolicyType.Household && isAdmin($roleSelection)}
     <p>
       <span class="header">Household ID<span class="required">*</span></span>
-      <TextField placeholder={'1234567'} bind:value={householdId} on:blur={updateHouseholdId} />
+      <TextField {maxlength} bind:value={householdId} on:blur={updateHouseholdId} />
     </p>
   {/if}
 
   {#if policy.type === PolicyType.Team}
     <p>
       <span class="header">Policy name<span class="required">*</span></span>
-      <TextField bind:value={policyName} on:blur={updatePolicyName} />
+      <TextField {maxlength} bind:value={policyName} on:blur={updatePolicyName} />
       <Description>Appears in your statements</Description>
     </p>
 
@@ -269,17 +270,17 @@ p {
     </p>
     <p>
       <span class="header">Cost center<span class="required">*</span></span>
-      <TextField placeholder={'1234567'} bind:value={costCenter} on:blur={updateCostCenter} />
+      <TextField {maxlength} bind:value={costCenter} on:blur={updateCostCenter} />
     </p>
 
     <p>
       <span class="header">Account<span class="required">*</span></span>
-      <TextField placeholder="12345" bind:value={account} on:blur={updateAccount} />
+      <TextField {maxlength} bind:value={account} on:blur={updateAccount} />
     </p>
 
     <p>
       <span class="header">Account Detail</span>
-      <TextField placeholder="details" bind:value={accountDetail} on:blur={updateAccountDetail} />
+      <TextField {maxlength} bind:value={accountDetail} on:blur={updateAccountDetail} />
     </p>
   {/if}
 

--- a/src/pages/policies/new.svelte
+++ b/src/pages/policies/new.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { Breadcrumb, Description, SearchableSelect } from 'components'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import { entityCodes, loadEntityCodes } from 'data/entityCodes'
 import { createPolicy } from 'data/policies'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -48,7 +49,7 @@ const validateForm = (formData: any) => {
 
   <p>
     <span class="header">Policy name<span class="required">*</span></span>
-    <TextField autofocus bind:value={policyName} />
+    <TextField {maxlength} autofocus bind:value={policyName} />
   </p>
 
   <p>
@@ -58,17 +59,17 @@ const validateForm = (formData: any) => {
 
   <p>
     <span class="header">Cost center<span class="required">*</span></span>
-    <TextField placeholder="ABCD12" bind:value={costCenter} />
+    <TextField {maxlength} label="ABCD12" bind:value={costCenter} />
   </p>
 
   <p>
     <span class="header">Account<span class="required">*</span></span>
-    <TextField placeholder="12345" bind:value={account} />
+    <TextField {maxlength} label="12345" bind:value={account} />
   </p>
 
   <p>
     <span class="header">Account Detail</span>
-    <TextField placeholder="details" bind:value={accountDetail} />
+    <TextField label="details" {maxlength} bind:value={accountDetail} />
     <Description>Appears in your statements</Description>
   </p>
 

--- a/src/pages/settings/personal.svelte
+++ b/src/pages/settings/personal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import user, { attachUserPhoto, updateUser } from '../../authn/user'
 import { Breadcrumb, CountrySelector, FileDropArea, RadioOptions } from 'components'
+import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import { upload } from 'data'
 import { policies } from 'data/policies'
 import { assertEmailAddress } from '../../validation/assertions'
@@ -145,7 +146,7 @@ p {
     />
   </p>
   {#if notification_email === NOTIFICATION_OPTION_CUSTOM}
-    <TextField placeholder={'Custom email'} bind:value={email_override} on:blur={updateCustomEmail} />
+    <TextField {maxlength} label="Custom email" bind:value={email_override} on:blur={updateCustomEmail} />
   {/if}
 
   <p>


### PR DESCRIPTION
- added maxlength const
- set maxlength in all text/number inputs
- TextArea will now show how many characters are left TextField does not do this
- Added required prop to MoneyInput (did not use it yet in any instances)
- further changes will need to be made in ui-components