### PR TITLE
hide inactive items on policy detail page and more...

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -290,4 +290,6 @@ export const itemIsApproved = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Approved
 }
 
+export const itemIsInactive = (item: PolicyItem): boolean => {
+  return item.coverage_status === ItemCoverageStatus.Inactive
 }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -283,5 +283,6 @@ function updateStoreItem(updatedItem: PolicyItem) {
 }
 
 export const itemIsActive = (item: PolicyItem): boolean => {
-  return item.coverage_status == ItemCoverageStatus.Approved
+  return item.coverage_status !== ItemCoverageStatus.Inactive
+}
 }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -285,4 +285,9 @@ function updateStoreItem(updatedItem: PolicyItem) {
 export const itemIsActive = (item: PolicyItem): boolean => {
   return item.coverage_status !== ItemCoverageStatus.Inactive
 }
+
+export const itemIsApproved = (item: PolicyItem): boolean => {
+  return item.coverage_status === ItemCoverageStatus.Approved
+}
+
 }

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -2,7 +2,7 @@
 import { ClaimsTable } from 'components'
 import { claimIsOpen } from 'data/claims'
 import { getNameOfPolicy, loadPolicy, Policy, PolicyType, selectedPolicy } from 'data/policies'
-import { itemIsActive, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
+import { itemIsApproved, itemIsActive, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
 import { formatDate } from 'components/dates'
 import { isLoadingById, loading } from 'components/progress'
 import { formatFriendlyDate } from 'helpers/date'
@@ -29,13 +29,13 @@ $: policyId && loadItems(policyId)
 $: items = $selectedPolicyItems.filter(itemIsActive).sort((a, b) =>
   a.coverage_status === b.coverage_status ? 0 : a.coverage_status > b.coverage_status ? 1 : -1
 )
-$: activeItems = items.filter(itemIsActive)
+$: approvedItems = items.filter(itemIsApproved)
 $: claims = policy?.claims || []
 $: openClaimCount = claims.filter(claimIsOpen).length
 $: policyName = getNameOfPolicy(policy)
 $: policyName && (metatags.title = formatPageTitle(`Policies > ${policyName}`))
-$: coverage = formatMoney(activeItems.reduce((sum, item) => sum + item.coverage_amount, 0))
-$: premium = formatMoney(activeItems.reduce((sum, item) => sum + item.annual_premium, 0))
+$: coverage = formatMoney(approvedItems.reduce((sum, item) => sum + item.coverage_amount, 0))
+$: premium = formatMoney(approvedItems.reduce((sum, item) => sum + item.annual_premium, 0))
 </script>
 
 <style>
@@ -136,7 +136,7 @@ th {
     </Datatable.Data>
   </Datatable>
 
-  <h4>Items <span class="subtext">({activeItems?.length} active)</span></h4>
+  <h4>Items <span class="subtext">({approvedItems?.length} covered)</span></h4>
   {#if $loading && isLoadingById(`policies/${policyId}/items`)}
     Loading items...
   {:else}

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -26,7 +26,7 @@ $: members = policy.members || []
 
 $: policyId && loadItems(policyId)
 // sort items so inactive is last
-$: items = $selectedPolicyItems.sort((a, b) =>
+$: items = $selectedPolicyItems.filter(itemIsActive).sort((a, b) =>
   a.coverage_status === b.coverage_status ? 0 : a.coverage_status > b.coverage_status ? 1 : -1
 )
 $: activeItems = items.filter(itemIsActive)

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { CardsGrid, ItemsTable, Row } from 'components'
 import { isLoadingPolicyItems, loading } from 'components/progress'
-import { deleteItem, ItemCoverageStatus, loadItems, PolicyItem, selectedPolicyItems } from 'data/items'
+import {deleteItem, itemIsInactive, itemIsActive, loadItems, PolicyItem, selectedPolicyItems} from 'data/items'
 import { getNameOfPolicy, selectedPolicy } from 'data/policies'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import * as routes from 'helpers/routes'
@@ -11,8 +11,8 @@ import { Button, Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
 
 $: policyId = $selectedPolicyId
-$: activeItems = $selectedPolicyItems.filter((item) => item.coverage_status !== ItemCoverageStatus.Inactive)
-$: inactiveItems = $selectedPolicyItems.filter((item) => item.coverage_status === ItemCoverageStatus.Inactive)
+$: activeItems = $selectedPolicyItems.filter(itemIsActive)
+$: inactiveItems = $selectedPolicyItems.filter(itemIsInactive)
 
 onMount(() => {
   loadItems(policyId)


### PR DESCRIPTION
### Fixed
- Fix logic for coverage & premium totals. It was including all non-`Inactive` items, rather than only `Approved` items.
### Changed
- Hide `Inactive` items on the policy detail page.
### Added
- Add `itemIsInactive` helper and use coverage status helpers on the Policy Items page.