### PR TITLE
resolve "Rollup 'sourcemap'" warning

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,7 @@ export default {
 	output: {
 		file: 'dist/bundle.js',
 		format: 'iife',
-		sourcemap: production,
+		sourcemap: !production,
 	},
 	plugins: [
 		svelte({


### PR DESCRIPTION
"Rollup 'sourcemap' option must be set to generate source maps."