### PR TITLE
remove unused isMemberOfPolicy property from FilePreview

### DIFF
--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -8,7 +8,6 @@ import { Progress } from '@silintl/ui-components'
 
 export let previews = [] as ClaimFile[]
 export let uploading: boolean = false
-export let isMemberOfPolicy: boolean = false
 
 let selectedId: string = ''
 

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -347,7 +347,7 @@ const isFileUploadedByPurpose = (purpose: ClaimFilePurpose, files: ClaimFile[]):
         <img class="receipt" src={previewFile.file?.url} alt="document" on:error={onImgError} />
       {/if}
 
-      <FilePreview class="pointer w-50" previews={claimFiles} {isMemberOfPolicy} on:preview={onPreview} />
+      <FilePreview class="pointer w-50" previews={claimFiles} on:preview={onPreview} />
 
       {#if showUploadButton}
         <Button raised disabled={noFilesUploaded} on:click={onSubmit}>{uploadLabelForButton}</Button>


### PR DESCRIPTION
Avoids warning on build:
```
[build:dev ] (!) Plugin svelte: FilePreview has unused export property 'isMemberOfPolicy'. If it is for external reference only, please consider using `export const isMemberOfPolicy`
[build:dev ] src/components/FilePreview/FilePreview.svelte
[build:dev ]  6: export let previews = [];
[build:dev ]  7: export let uploading = false;
[build:dev ]  8: export let isMemberOfPolicy = false;
[build:dev ]                ^
[build:dev ]  9: let selectedId = '';
[build:dev ] 10: const dispatch = createEventDispatcher();
```
