### PR TITLE
remove unused selector

### DIFF
--- a/src/pages/privacy.svelte
+++ b/src/pages/privacy.svelte
@@ -5,8 +5,7 @@ import { Page } from '@silintl/ui-components'
 </script>
 
 <style>
-ol,
-ul {
+ol {
   line-height: 1.5;
 }
 table {


### PR DESCRIPTION
Eliminates the following warning:
```
[build:dev ] (!) Plugin svelte: Unused CSS selector "ul"
[build:dev ] src/pages/privacy.svelte
[build:dev ]  7: <style>
[build:dev ]  8: ol,
[build:dev ]  9: ul {
[build:dev ]     ^
[build:dev ] 10:   line-height: 1.5;
[build:dev ] 11: }
```