### PR TITLE
Remove home breadcrumb and add icons for claims/items

### DIFF
--- a/src/components/Breadcrumb.svelte
+++ b/src/components/Breadcrumb.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { HOME } from 'helpers/routes'
-import { goto, url } from '@roxi/routify'
+import { url } from '@roxi/routify'
 
-export let links: { url?: string; name?: string }[] = []
+export let links: { url?: string; name?: string, icon?: string }[] = []
 export let hasHome = false
 
-let urls: { url: string; name: string }[] = []
+let urls: { url: string; name: string, icon?: string }[] = []
 
 $: if (links.length === 0) {
   let path = $url().split('/')
@@ -25,7 +25,7 @@ $: if (links.length === 0) {
   urls = []
   links.forEach((val) => {
     if (val.url && val.name) {
-      urls = [...urls, { url: val.url, name: val.name }]
+      urls = [...urls, { url: val.url, name: val.name, icon: val?.icon }]
     }
   })
 }
@@ -38,6 +38,7 @@ a {
 }
 .breadcrumb-icon {
   margin: 0 3px;
+  color: var(--mdc-theme-text-icon-on-background, rgba(0, 0, 0, 0.38));
 }
 .breadcrumb-home {
   display: inherit;
@@ -48,20 +49,25 @@ a {
 <div class="flex text-align-center align-items-center {$$props.class}">
   <!-- svelte-ignore a11y-invalid-attribute -->
   {#if hasHome}
-    <a href={HOME} class="capitalize"
-      ><i class="material-icons mdc-list-item__graphic money-icon breadcrumb-icon breadcrumb-home" aria-hidden="true"
-        >home</i
-      ></a
-    ><!--
-  --><i class="material-icons mdc-list-item__graphic money-icon breadcrumb-icon" aria-hidden="true"
-      >chevron_right</i
-    >
+    <a href={HOME} class="capitalize">
+      <i class="material-icons breadcrumb-icon breadcrumb-home" aria-hidden="true">
+        home
+      </i>
+    </a>
+    <i class="material-icons breadcrumb-icon" aria-hidden="true">
+      chevron_right
+    </i>
   {/if}
   {#each urls as val, i}
     <!-- svelte-ignore a11y-invalid-attribute -->
-    <a on:click={() => $goto(val.url)} href="" class="capitalize">{val.name}</a><!--
-    -->{#if urls.length - 1 != i}
-      <i class="material-icons mdc-list-item__graphic money-icon breadcrumb-icon" aria-hidden="true">chevron_right</i>
+    {#if val.icon}
+      <i class="material-icons breadcrumb-icon" aria-hidden="true">
+        {val.icon}
+      </i>
     {/if}
+      <a href={val.url} class="capitalize">{val.name}</a>
+      {#if urls.length - 1 != i}
+        <i class="material-icons breadcrumb-icon" aria-hidden="true">chevron_right</i>
+      {/if}
   {/each}
 </div>

--- a/src/components/Breadcrumb.svelte
+++ b/src/components/Breadcrumb.svelte
@@ -3,7 +3,7 @@ import { HOME } from 'helpers/routes'
 import { goto, url } from '@roxi/routify'
 
 export let links: { url?: string; name?: string }[] = []
-export let hasHome = true
+export let hasHome = false
 
 let urls: { url: string; name: string }[] = []
 

--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { UserAppRole } from 'data/user'
+import { isAdmin } from 'data/user'
 import { Breadcrumb, ClaimCards, ClaimsTable, Row } from 'components'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
 import { loadItems } from 'data/items'
@@ -16,8 +16,7 @@ export let policyId: string
 $: policy = $selectedPolicy
 
 $: policyName = getNameOfPolicy(policy)
-$: isAdmin = $roleSelection !== UserAppRole.Customer
-$: adminBreadcrumbs = isAdmin
+$: adminBreadcrumbs = isAdmin($roleSelection)
   ? [
       { name: 'Policies', url: POLICIES },
       { name: policyName, url: policyDetails(policyId) },
@@ -36,7 +35,9 @@ const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(ev
 </script>
 
 <Page layout="grid">
-  <Breadcrumb links={breadcrumbLinks} />
+  {#if isAdmin($roleSelection)}
+    <Breadcrumb links={breadcrumbLinks} />
+  {/if}
   <!-- <Row cols={'12'}>
     <Button raised url={customerClaimsNew(policyId)}>New claim</Button>
   </Row> -->

--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { isAdmin } from 'data/user'
+import { isAdmin as checkIsAdmin } from 'data/user'
 import { Breadcrumb, ClaimCards, ClaimsTable, Row } from 'components'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
 import { loadItems } from 'data/items'
@@ -14,16 +14,17 @@ import { onMount } from 'svelte'
 
 export let policyId: string
 $: policy = $selectedPolicy
+$: isAdmin = checkIsAdmin($roleSelection)
 
 $: policyName = getNameOfPolicy(policy)
-$: adminBreadcrumbs = isAdmin($roleSelection)
+$: adminBreadcrumbs = isAdmin
   ? [
       { name: 'Policies', url: POLICIES },
       { name: policyName, url: policyDetails(policyId) },
     ]
   : []
 
-$: breadcrumbLinks = [...adminBreadcrumbs, { name: 'Claims', url: customerClaims(policyId) }]
+$: breadcrumbLinks = [...adminBreadcrumbs, { name: 'Claims', url: customerClaims(policyId), icon: 'assignment' }]
 $: metatags.title = formatPageTitle('Claims')
 
 onMount(() => {
@@ -35,7 +36,7 @@ const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(ev
 </script>
 
 <Page layout="grid">
-  {#if isAdmin($roleSelection)}
+  {#if isAdmin}
     <Breadcrumb links={breadcrumbLinks} />
   {/if}
   <!-- <Row cols={'12'}>

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -115,7 +115,7 @@ $: adminBreadcrumbs = isAdmin
     ]
   : []
 
-const claimsBreadcrumb = { name: 'Claims', url: customerClaims(policyId) }
+const claimsBreadcrumb = { name: 'Claims', url: customerClaims(policyId), icon: 'assignment' }
 $: thisClaimBreadcrumb = { name: claimName || 'This item', url: customerClaimDetails(policyId, claimId) }
 $: breadcrumbLinks = [...adminBreadcrumbs, claimsBreadcrumb, thisClaimBreadcrumb]
 $: claimName && (metatags.title = formatPageTitle(`Claims > ${claimName}`))

--- a/src/pages/policies/[policyId]/items/[itemId].svelte
+++ b/src/pages/policies/[policyId]/items/[itemId].svelte
@@ -63,7 +63,7 @@ $: adminBreadcrumbs = isAdmin
       { name: policyName, url: policyDetails(policyId) },
     ]
   : []
-const itemsBreadcrumb = { name: 'Items', url: itemsRoute(policyId) }
+const itemsBreadcrumb = { name: 'Items', url: itemsRoute(policyId), icon: 'beach_access'   }
 $: thisItemBreadcrumb = { name: itemName || 'This item', url: itemDetails(policyId, itemId) }
 $: breadcrumbLinks = [...adminBreadcrumbs, itemsBreadcrumb, thisItemBreadcrumb]
 $: itemName && (metatags.title = formatPageTitle(`Items > ${itemName}`))


### PR DESCRIPTION
- Default to no home icon
- add umbrella and clipboard icons to items/claims
- code cleanup
![image](https://user-images.githubusercontent.com/70765247/148604769-85ad3235-d45c-4c36-9716-45063d1c7897.png)
