### PR TITLE
fix data not reloading on policy change

### DIFF
--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -13,7 +13,7 @@ import { Page } from '@silintl/ui-components'
 export let policyId: string
 
 $: policy = $selectedPolicy
-$: policy && loadClaimsByPolicyId(policyId)
+$: policyId && loadClaimsByPolicyId(policyId)
 $: isAdmin = checkIsAdmin($roleSelection)
 
 $: policyName = getNameOfPolicy(policy)

--- a/src/pages/policies/[policyId]/claims.svelte
+++ b/src/pages/policies/[policyId]/claims.svelte
@@ -2,7 +2,6 @@
 import { isAdmin as checkIsAdmin } from 'data/user'
 import { Breadcrumb, ClaimCards, ClaimsTable, Row } from 'components'
 import { Claim, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
-import { loadItems } from 'data/items'
 import { getNameOfPolicy, selectedPolicy } from 'data/policies'
 import { roleSelection } from 'data/role-policy-selection'
 import { customerClaims, customerClaimDetails, POLICIES, policyDetails } from 'helpers/routes'
@@ -10,10 +9,11 @@ import { formatPageTitle } from 'helpers/pageTitle'
 import { items } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
-import { onMount } from 'svelte'
 
 export let policyId: string
+
 $: policy = $selectedPolicy
+$: policy && loadClaimsByPolicyId(policyId)
 $: isAdmin = checkIsAdmin($roleSelection)
 
 $: policyName = getNameOfPolicy(policy)
@@ -26,11 +26,6 @@ $: adminBreadcrumbs = isAdmin
 
 $: breadcrumbLinks = [...adminBreadcrumbs, { name: 'Claims', url: customerClaims(policyId), icon: 'assignment' }]
 $: metatags.title = formatPageTitle('Claims')
-
-onMount(() => {
-  loadItems(policyId)
-  loadClaimsByPolicyId(policyId)
-})
 
 const onGotoClaim = (event: CustomEvent<Claim>) => $goto(customerClaimDetails(event.detail.policy_id, event.detail.id))
 </script>

--- a/src/pages/policies/[policyId]/items.svelte
+++ b/src/pages/policies/[policyId]/items.svelte
@@ -1,22 +1,18 @@
 <script lang="ts">
 import { ItemsTable, Row, SearchForm } from 'components'
 import { isLoadingPolicyItems, loading } from 'components/progress'
-import {deleteItem, loadItems, PolicyItem, selectedPolicyItems} from 'data/items'
+import {deleteItem, loadItems, selectedPolicyItems} from 'data/items'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import * as routes from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Button, Page } from '@silintl/ui-components'
-import { onMount } from 'svelte'
 
 let searchText = ''
 let filteredItems = $selectedPolicyItems
 
 $: policyId = $selectedPolicyId
-
-onMount(() => {
-  loadItems(policyId)
-})
+$: policyId && loadItems(policyId)
 
 $: metatags.title = formatPageTitle('Home')
 $: filteredItems = $selectedPolicyItems.filter(


### PR DESCRIPTION
# Fix
- data not reloading when switching policies on claims/items views
# Remove
- removed some unused code
- loading data in onMount no longer necessary