### PR TITLE
update ui-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@rollup/plugin-node-resolve": "^13.0.6",
         "@rollup/plugin-typescript": "^8.3.0",
         "@roxi/routify": "^2.18.3",
-        "@silintl/ui-components": "^3.10.5",
+        "@silintl/ui-components": "^3.10.6",
         "@tsconfig/svelte": "^2.0.1",
         "@types/croppie": "^2.6.1",
         "@types/gtag.js": "^0.0.8",
@@ -2753,9 +2753,9 @@
       }
     },
     "node_modules/@silintl/ui-components": {
-      "version": "3.10.5",
-      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-3.10.5.tgz",
-      "integrity": "sha512-/Xt9aCzVM7Ww5MvEsOYfKDTE62667VwuyqkpscdDeBjXrfZuT+iAymjVQkVZRjL8XtPoGxzjDcxGVLKOqt144Q==",
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-3.10.6.tgz",
+      "integrity": "sha512-cVZZg7ApGjZpN5bWT4XXqoJPide5qVCV+ktyCcZJBJqPgOnryb9dLuYpAcBJoQ2mUp6dHxwe1IEfxe29G+ZtlQ==",
       "dev": true,
       "peerDependencies": {
         "@roxi/routify": "^2.x",
@@ -11044,9 +11044,9 @@
       }
     },
     "@silintl/ui-components": {
-      "version": "3.10.5",
-      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-3.10.5.tgz",
-      "integrity": "sha512-/Xt9aCzVM7Ww5MvEsOYfKDTE62667VwuyqkpscdDeBjXrfZuT+iAymjVQkVZRjL8XtPoGxzjDcxGVLKOqt144Q==",
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-3.10.6.tgz",
+      "integrity": "sha512-cVZZg7ApGjZpN5bWT4XXqoJPide5qVCV+ktyCcZJBJqPgOnryb9dLuYpAcBJoQ2mUp6dHxwe1IEfxe29G+ZtlQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@rollup/plugin-node-resolve": "^13.0.6",
     "@rollup/plugin-typescript": "^8.3.0",
     "@roxi/routify": "^2.18.3",
-    "@silintl/ui-components": "^3.10.5",
+    "@silintl/ui-components": "^3.10.6",
     "@tsconfig/svelte": "^2.0.1",
     "@types/croppie": "^2.6.1",
     "@types/gtag.js": "^0.0.8",


### PR DESCRIPTION
- updated ui-components to 3.10.6 (removes a svelte a11y warning)