### PR TITLE
don't show team for household policy settings

### DIFF
--- a/src/components/forms/DependentForm.svelte
+++ b/src/components/forms/DependentForm.svelte
@@ -25,6 +25,9 @@ export let dependents: PolicyDependent[] = []
 export let isHouseholdPolicy = true
 
 const dispatch = createEventDispatcher()
+
+let teamOrHousehold: string = isHouseholdPolicy ? 'household' : 'team'
+
 const relationshipOptions = [
   {
     label: 'Spouse',
@@ -44,7 +47,7 @@ const permissionOptions = [
     disabled: false,
   },
   {
-    label: 'Can edit items and claims for team',
+    label: `Can edit items and claims for ${teamOrHousehold}`,
     value: 'can-edit',
     disabled: false,
   },


### PR DESCRIPTION
When adding a dependent to household policies "team" was being shown

![image](https://user-images.githubusercontent.com/70765247/150390275-d5b5d148-77a7-40c3-b7bd-b18310099a4c.png)
