### PR TITLE
claim card should show "receipt" instead of "changes"

### DIFF
--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -24,6 +24,12 @@ export const needsReview: State = {
   title: 'Needs claim review',
 }
 
+export const needsReceipt: State = {
+  ...needsReview,
+  icon: 'error',
+  title: 'Needs receipt',
+}
+
 export const pending: State = {
   icon: 'watch_later',
   color: '--mdc-theme-neutral-variant',
@@ -66,7 +72,7 @@ export const claimStates: { [stateName: string]: State } = {
   Review1: pendingClaim,
   Review2: pendingClaim,
   Review3: { ...pendingClaim, title: 'Awaiting review 3/3' },
-  ReceiptSecondary: warning,
+  ReceiptSecondary: needsReceipt,
   RevisionSecondary: warning,
   Receipt: { ...approved, icon: 'done' },
   Paid: {


### PR DESCRIPTION
- used `needsReview` state but modified the icon and title for `needsReceipt` state

![image](https://user-images.githubusercontent.com/70765247/158319630-2eab6a94-4f33-4c2e-9350-c635ad0064ac.png)
