### PR TITLE
refactor FilePreview and use in personal settings

### DIFF
--- a/src/components/FilePreview/FilePreview.svelte
+++ b/src/components/FilePreview/FilePreview.svelte
@@ -1,37 +1,17 @@
 <script lang="ts">
 import Banner from '../components/Banner.svelte'
-import type { ClaimFile } from 'data/claims'
 import { formatDate } from '../../helpers/dates'
+import { Button } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
-import { flip } from 'svelte/animate'
-import { Button, Progress } from '@silintl/ui-components'
 
-export let allowDelete: boolean = false
-export let previews = [] as ClaimFile[]
-export let uploading: boolean = false
-
-let selectedId: string = ''
+export let allowDelete = false
+export let label = ''
+export let date = ''
+export let id = ''
+export let purpose = ''
+export let btnLabel = 'delete'
 
 const dispatch = createEventDispatcher()
-
-const isSelected = {} as any
-
-$: isSelected[selectedId] = true
-$: selectedId && setOthersFalse(selectedId)
-
-const setOthersFalse = (id: string) => {
-  for (const key of Object.keys(isSelected)) {
-    if (key != id) {
-      isSelected[key] = false
-    }
-  }
-}
-
-const onClick = (id: string) => {
-  selectedId = id
-
-  dispatch('preview', id)
-}
 
 function onDelete(event: CustomEvent, id: string) {
   event.preventDefault()
@@ -44,37 +24,21 @@ function onDelete(event: CustomEvent, id: string) {
 <style>
 .preview {
   background-color: hsla(213, 26%, 23%, 1);
+  width: 340px;
 }
 .preview:hover {
   background-color: hsla(213, 26%, 23%, 0.8);
 }
-.selected {
-  background-color: hsla(213, 26%, 23%, 0.6);
-}
 </style>
 
-<div class="mt-10px py-10px {$$props.class}">
-  {#each previews as preview (preview.id)}
-    <div
-      on:click|preventDefault={() => onClick(preview.id)}
-      animate:flip={{ duration: 500 }}
-      class:selected={isSelected[preview.id]}
-      class="preview flex justify-between align-items-center br-8px p-10px mb-1"
-    >
-      <div>
-        <p class="white my-0">{preview.file.name}</p>
-        <p class="white my-0">{formatDate(preview.created_at)}</p>
-      </div>
-      {#if allowDelete}
-        <Button class="delete-button" raised on:click={(evt) => onDelete(evt, preview.id)}>Delete</Button>
-      {:else if preview.purpose}
-        <Banner class="mdc-bold-font" color="hsla(213, 8%, 46%, 1)" background="hsla(213, 22%, 94%, 1)"
-          >{preview.purpose}</Banner
-        >
-      {/if}
-    </div>
-  {/each}
-  {#if uploading}
-    <Progress.Circular />
+<div class="preview flex justify-between align-items-center br-8px p-10px mb-1 {$$props.class}" on:click>
+  <div>
+    <p class="white my-0">{label}</p>
+    <p class="white my-0">{formatDate(date)}</p>
+  </div>
+  {#if allowDelete}
+    <Button class="delete-button" raised on:click={(evt) => onDelete(evt, id)}>{btnLabel}</Button>
+  {:else if purpose}
+    <Banner class="mdc-bold-font" color="hsla(213, 8%, 46%, 1)" background="hsla(213, 22%, 94%, 1)">{purpose}</Banner>
   {/if}
 </div>

--- a/src/components/FilePreview/FilePreviews.svelte
+++ b/src/components/FilePreview/FilePreviews.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+import type { ClaimFile } from 'data/claims'
+import FilePreview from './FilePreview.svelte'
+import { Progress } from '@silintl/ui-components'
+import { createEventDispatcher } from 'svelte'
+import { flip } from 'svelte/animate'
+
+export let allowDelete = false
+export let previews = [] as ClaimFile[]
+export let uploading: boolean = false
+
+let selectedId: string = ''
+
+const isSelected = {} as any
+
+$: isSelected[selectedId] = true
+$: selectedId && setOthersFalse(selectedId)
+
+const dispatch = createEventDispatcher()
+
+const onClick = (e: Event, id: string) => {
+  e.preventDefault()
+  selectedId = id
+
+  dispatch('preview', id)
+}
+
+const setOthersFalse = (id: string) => {
+  for (const key of Object.keys(isSelected)) {
+    if (key != id) {
+      isSelected[key] = false
+    }
+  }
+}
+</script>
+
+<style>
+.selected {
+  background-color: hsla(213, 26%, 23%, 0.6);
+}
+</style>
+
+<div class="mt-10px py-10px {$$props.class}">
+  {#each previews as preview (preview.id)}
+    <div animate:flip={{ duration: 500 }}>
+      <FilePreview
+        {allowDelete}
+        date={preview.created_at}
+        label={preview.file.name}
+        id={preview.id}
+        purpose={preview.purpose}
+        class={isSelected[preview.id] ? 'selected w-100' : 'w-100'}
+        on:click={(e) => onClick(e, preview.id)}
+        on:deleted
+        on:preview
+      />
+    </div>
+  {/each}
+  {#if uploading}
+    <Progress.Circular />
+  {/if}
+</div>

--- a/src/components/FilePreview/index.ts
+++ b/src/components/FilePreview/index.ts
@@ -1,4 +1,6 @@
 import './_index.scss'
+import FilePreviews from './FilePreviews.svelte'
 import FilePreview from './FilePreview.svelte'
 
-export default FilePreview
+export default FilePreviews
+export { FilePreview }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,7 +16,8 @@ import DependentForm from './forms/DependentForm.svelte'
 import Description from './Description.svelte'
 import FileDropArea from './FileDropArea'
 import FileLink from './FileLink.svelte'
-import FilePreview from './FilePreview'
+import { FilePreview } from './FilePreview'
+import FilePreviews from './FilePreview'
 import ItemBanner from './banners/ItemBanner.svelte'
 import ItemDeleteModal from './ItemDeleteModal.svelte'
 import ItemDetails from './ItemDetails.svelte'
@@ -50,6 +51,7 @@ export {
   FileDropArea,
   FileLink,
   FilePreview,
+  FilePreviews,
   ItemBanner,
   ItemDeleteModal,
   ItemDetails,

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -9,7 +9,7 @@ import {
   MessageBanner,
   ConvertCurrencyLink,
   FileDropArea,
-  FilePreview,
+  FilePreviews,
   Row,
   RevokeModal,
 } from 'components'
@@ -380,7 +380,7 @@ const isFileUploadedByPurpose = (purpose: ClaimFilePurpose, files: ClaimFile[]):
         <img class="receipt" src={previewFile.file?.url} alt="document" on:error={onImgError} />
       {/if}
 
-      <FilePreview
+      <FilePreviews
         class="pointer w-50"
         {allowDelete}
         previews={claimFiles}

--- a/src/pages/settings/personal.svelte
+++ b/src/pages/settings/personal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Breadcrumb, CountrySelector, FileDropArea, RadioOptions, RemoveProfilePicModal } from 'components'
+import { Breadcrumb, CountrySelector, FileDropArea, FilePreview, RadioOptions, RemoveProfilePicModal } from 'components'
 import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import { upload } from 'data'
 import { policies } from 'data/policies'
@@ -133,6 +133,10 @@ function onDelete(e: CustomEvent) {
   }
   open = false
 }
+
+function openPhoto() {
+  window.open($user.photo_file?.url, '_blank')
+}
 </script>
 
 <style>
@@ -194,8 +198,13 @@ p {
     <div bind:this={croppieContainer} />
   </div>
 
-  {#if $user.photo_file_id}
-    <Button on:click={() => (open = true)}>remove profile picture</Button>
+  {#if $user.photo_file?.id}
+    <FilePreview
+      label="Profile Picture — {($user.photo_file?.size / 1000).toFixed(2)}kb"
+      allowDelete
+      on:deleted={() => (open = true)}
+      on:click={openPhoto}
+    />
   {/if}
 
   {#if !croppieIsHidden}


### PR DESCRIPTION
- refactor `FilePreview` into `FilePreview` and `FilePreviews` to decouple from `claims`
- use in personal settings to match design

![image](https://user-images.githubusercontent.com/70765247/158743641-7a3a7863-c7b4-4fc2-b217-4f67feb07c53.png)
