### PR TITLE
Add strikes to policies

### DIFF
--- a/src/components/Strikes.svelte
+++ b/src/components/Strikes.svelte
@@ -8,6 +8,7 @@ export let userIsAdmin = false
 export let policy = {} as Policy
 
 let strikeDescription = ''
+let showStrikeForm = false
 
 const HeaderRow = Datatable.Header
 const HeaderItem = Datatable.Header.Item
@@ -32,12 +33,17 @@ const addStrike = () => {
       by 20%. Each strike lasts 2 years. Multiple strikes can be on a policy at a time.
     </p>
   {:else}
-    <Form class="mb-2">
-      <p>
-        <TextArea {maxlength} label="Add a Strike to this policy" rows="4" bind:value={strikeDescription} />
-        <Button disabled={!strikeDescription} on:click={addStrike}>add a strike</Button>
-      </p>
-    </Form>
+    <Button class="mb-1" on:click={() => (showStrikeForm = !showStrikeForm)}>
+      {showStrikeForm ? 'hide' : 'add a strike'}
+    </Button>
+    {#if showStrikeForm}
+      <Form class="mb-2">
+        <p>
+          <TextArea {maxlength} label="Add a Strike to this policy" rows="4" bind:value={strikeDescription} />
+          <Button disabled={!strikeDescription} on:click={addStrike}>submit</Button>
+        </p>
+      </Form>
+    {/if}
   {/if}
   <Datatable>
     <HeaderRow>

--- a/src/components/Strikes.svelte
+++ b/src/components/Strikes.svelte
@@ -19,6 +19,7 @@ $: strikes = policy.strikes || ([] as Strike[])
 
 const addStrike = () => {
   createPolicyStrike(policy.id, strikeDescription)
+  strikeDescription = ''
 }
 </script>
 

--- a/src/components/Strikes.svelte
+++ b/src/components/Strikes.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+import { MAX_TEXT_AREA_LENGTH as maxlength } from 'components/const'
+import { createPolicyStrike, Policy, Strike } from 'data/policies'
+import { formatDate, formatFriendlyDate } from 'helpers/dates'
+import { Button, Datatable, Form, TextArea } from '@silintl/ui-components'
+
+export let userIsAdmin = false
+export let policy = {} as Policy
+
+let strikeDescription = ''
+
+const HeaderRow = Datatable.Header
+const HeaderItem = Datatable.Header.Item
+const TableBody = Datatable.Data
+const DataRow = Datatable.Data.Row
+const RowItem = Datatable.Data.Row.Item
+
+$: strikes = policy.strikes || ([] as Strike[])
+
+const addStrike = () => {
+  createPolicyStrike(policy.id, strikeDescription)
+}
+</script>
+
+{#if userIsAdmin}
+  <h4>Strikes</h4>
+  <Form class="mb-2">
+    <p>
+      <TextArea {maxlength} label="Add a Strike to this policy" rows="4" bind:value={strikeDescription} />
+      <Button disabled={!strikeDescription} on:click={addStrike}>add a strike</Button>
+    </p>
+  </Form>
+  <Datatable>
+    <HeaderRow>
+      <HeaderItem>Date Created</HeaderItem>
+      <HeaderItem>Updated At</HeaderItem>
+      <HeaderItem>Description</HeaderItem>
+    </HeaderRow>
+    <TableBody>
+      {#each strikes as strike}
+        <DataRow>
+          <RowItem>{formatDate(strike.created_at)}</RowItem>
+          <RowItem>{formatFriendlyDate(strike.updated_at)}</RowItem>
+          <RowItem>{strike.description}</RowItem>
+        </DataRow>
+      {/each}
+    </TableBody>
+  </Datatable>
+{/if}

--- a/src/components/Strikes.svelte
+++ b/src/components/Strikes.svelte
@@ -22,14 +22,22 @@ const addStrike = () => {
 }
 </script>
 
-{#if userIsAdmin}
+{#if strikes.length || userIsAdmin}
   <h4>Strikes</h4>
-  <Form class="mb-2">
+  {#if !userIsAdmin}
     <p>
-      <TextArea {maxlength} label="Add a Strike to this policy" rows="4" bind:value={strikeDescription} />
-      <Button disabled={!strikeDescription} on:click={addStrike}>add a strike</Button>
+      <!-- TODO: Add strike rules to terms when finalized -->
+      This policy has been given a strike for suspicious or potentially abusive behavior. Each strike increases the deductible
+      by 20%. Each strike lasts 2 years. Multiple strikes can be on a policy at a time.
     </p>
-  </Form>
+  {:else}
+    <Form class="mb-2">
+      <p>
+        <TextArea {maxlength} label="Add a Strike to this policy" rows="4" bind:value={strikeDescription} />
+        <Button disabled={!strikeDescription} on:click={addStrike}>add a strike</Button>
+      </p>
+    </Form>
+  {/if}
   <Datatable>
     <HeaderRow>
       <HeaderItem>Date Created</HeaderItem>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -34,6 +34,7 @@ import MessageBanner from './banners/MessageBanner.svelte'
 import SearchableSelect from './SearchableSelect.svelte'
 import RemoveProfilePicModal from './RemoveProfilePicModal.svelte'
 import RevokeModal from './RevokeModal.svelte'
+import Strikes from './Strikes.svelte'
 
 export {
   AppDrawer,
@@ -72,4 +73,5 @@ export {
   MessageBanner,
   RemoveProfilePicModal,
   RevokeModal,
+  Strikes,
 }

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -179,6 +179,12 @@ export async function searchPoliciesFor(searchText: string, page = 1, limit = 20
   return response
 }
 
+export async function createPolicyStrike(id: string, description: string): Promise<any> {
+  const url = `policies/${id}/strikes`
+  const response = await CREATE(url, { description })
+  return response
+}
+
 export const getPolicyById = (policyId: string): Policy => {
   const policy = get(policies).find((policy) => policy.id === policyId) || ({} as Policy)
   return policy

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -191,7 +191,7 @@ export async function searchPoliciesFor(searchText: string, page = 1, limit = 20
 export async function createPolicyStrike(id: string, description: string): Promise<any> {
   const url = `policies/${id}/strikes`
   const response: Strike[] = await CREATE(url, { description })
-  const changedPolicy = { ...get(selectedPolicy), strikes: response }
+  const changedPolicy = { ...getPolicyById(id), strikes: response }
   updatePolicyStore(changedPolicy)
 }
 

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -21,6 +21,7 @@ export type Policy = {
   members?: PolicyMember[]
   name: string
   type: PolicyType
+  strikes: Strike[]
   updated_at: string /*Date*/
 }
 
@@ -33,6 +34,14 @@ export type PolicyInvite = {
 export enum PolicyType {
   Household = 'Household',
   Team = 'Team',
+}
+
+export type Strike = {
+  created_at: string
+  description: string
+  id: string
+  policy_id: string
+  updated_at: string
 }
 
 export type CreatePolicyRequestBody = {
@@ -181,8 +190,9 @@ export async function searchPoliciesFor(searchText: string, page = 1, limit = 20
 
 export async function createPolicyStrike(id: string, description: string): Promise<any> {
   const url = `policies/${id}/strikes`
-  const response = await CREATE(url, { description })
-  return response
+  const response: Strike[] = await CREATE(url, { description })
+  const changedPolicy = { ...get(selectedPolicy), strikes: response }
+  updatePolicyStore(changedPolicy)
 }
 
 export const getPolicyById = (policyId: string): Policy => {

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Breadcrumb, CardsGrid, ClaimsTable, ItemsTable, Row } from 'components'
+import { Breadcrumb, CardsGrid, ClaimsTable, ItemsTable, Row, Strikes } from 'components'
 import CustomerReport from '../components/CustomerReport.svelte'
 import { isLoadingById, loading } from 'components/progress'
 import { Claim, claimIsOpen, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
@@ -247,6 +247,8 @@ th {
   {/if}
 
   <CustomerReport {policy} />
+
+  <Strikes {userIsAdmin} {policy} />
 
   <div class="p-2" />
 </Page>


### PR DESCRIPTION
- add basic ability to add and view strikes on a policy
- show and explain strikes to customer (basics for now)

Admin view
![image](https://user-images.githubusercontent.com/70765247/159120774-b78e7311-8d10-4a47-9e3c-d6467e433de9.png)

customer view
![image](https://user-images.githubusercontent.com/70765247/159120787-699d381d-9bb5-4410-9816-7ee455868cd6.png)

Hide the form
![image](https://user-images.githubusercontent.com/70765247/159364698-beea0011-ff00-4877-b8f0-51b17a65135e.png)

![image](https://user-images.githubusercontent.com/70765247/159364558-ca9ac597-94d1-4df0-ad99-4373223867e5.png)
