### PR TITLE
add policyLedgerReports store and add notice

### DIFF
--- a/src/components/CustomerReport.svelte
+++ b/src/components/CustomerReport.svelte
@@ -20,7 +20,9 @@ $: ledgerReports = $policyLedgerReports
 
 async function getUsersReports() {
   const allReports = await getLedgerReports()
-  return allReports.filter((report) => report.file?.created_by_id === $user.id)
+  return allReports.filter(
+    (report) => report.file?.created_by_id === $user.id && report.file?.name.includes('riskman_policy')
+  )
 }
 
 async function createReport(e: CustomEvent) {

--- a/src/components/CustomerReport.svelte
+++ b/src/components/CustomerReport.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
 import CreateCustomerReportModal from './CreateCustomerReportModal.svelte'
 import type { Policy } from 'data/policies'
-import { createPolicyLedgerReport, LedgerReportType, policyLedgerReports } from 'data/ledger'
+import { createPolicyLedgerReport, getLedgerReports, LedgerReportType, policyLedgerReports } from 'data/ledger'
+import user from 'data/user'
 import { formatDateAndTime, formatFriendlyDate } from 'helpers/dates'
 import FileLink from './FileLink.svelte'
 import { Button, Datatable, setNotice } from '@silintl/ui-components'
+import { onMount } from 'svelte'
 
 export let policy: Policy
 
 let modalOpen = false
 
+onMount(async () => {
+  $policyLedgerReports = await getUsersReports()
+})
+
 $: ledgerReports = $policyLedgerReports
+
+async function getUsersReports() {
+  const allReports = await getLedgerReports()
+  return allReports.filter((report) => report.file?.created_by_id === $user.id)
+}
 
 async function createReport(e: CustomEvent) {
   const reportType: LedgerReportType = e.detail.type

--- a/src/components/CustomerReport.svelte
+++ b/src/components/CustomerReport.svelte
@@ -1,27 +1,30 @@
 <script lang="ts">
 import CreateCustomerReportModal from './CreateCustomerReportModal.svelte'
 import type { Policy } from 'data/policies'
-import { createPolicyLedgerReport, LedgerReport, LedgerReportType } from 'data/ledger'
+import { createPolicyLedgerReport, LedgerReportType, policyLedgerReports } from 'data/ledger'
 import { formatDateAndTime, formatFriendlyDate } from 'helpers/dates'
 import FileLink from './FileLink.svelte'
-import { Button, Datatable } from '@silintl/ui-components'
+import { Button, Datatable, setNotice } from '@silintl/ui-components'
 
 export let policy: Policy
 
-let ledgerReports: LedgerReport[] = []
 let modalOpen = false
+
+$: ledgerReports = $policyLedgerReports
 
 async function createReport(e: CustomEvent) {
   const reportType: LedgerReportType = e.detail.type
   const { month, year } = e.detail.date
 
   const report = await createPolicyLedgerReport(policy.id, reportType, month, year)
-  ledgerReports = [...ledgerReports, report]
+  if (!report.id) {
+    setNotice('No transactions found for this date, please try a different month or year.')
+  }
   modalOpen = false
 }
 </script>
 
-<Button on:click={() => (modalOpen = true)}>create a report</Button>
+<Button class="mb-1" on:click={() => (modalOpen = true)}>create a report</Button>
 <CreateCustomerReportModal {modalOpen} on:submit={createReport} on:cancel={() => (modalOpen = false)} />
 
 {#if ledgerReports.length > 0}

--- a/src/data/ledger.ts
+++ b/src/data/ledger.ts
@@ -1,6 +1,7 @@
 import type { PolicyType } from 'data/policies'
 import type { CoverFile } from 'data/file'
 import { CREATE, GET, UPDATE } from './index'
+import { writable } from 'svelte/store'
 
 export type LedgerReport = {
   id: string
@@ -71,6 +72,8 @@ export async function createLedgerReport(type: LedgerReportType, date: string): 
   return await CREATE('ledger-reports', params)
 }
 
+export const policyLedgerReports = writable<LedgerReport[]>([])
+
 export async function createPolicyLedgerReport(
   policyId: string,
   type: LedgerReportType,
@@ -82,7 +85,11 @@ export async function createPolicyLedgerReport(
     month,
     year,
   }
-  return await CREATE(`policies/${policyId}/ledger-reports`, params)
+  const response: LedgerReport = await CREATE(`policies/${policyId}/ledger-reports`, params)
+  if (response.id) {
+    policyLedgerReports.update((reports) => [...reports, response])
+  }
+  return response
 }
 
 export async function reconcileLedgerReport(reportId: string): Promise<LedgerReport> {

--- a/src/pages/admin/reports.svelte
+++ b/src/pages/admin/reports.svelte
@@ -39,7 +39,8 @@ async function createReport(e: CustomEvent) {
       <Datatable.Header.Item>File</Datatable.Header.Item>
     </Datatable.Header>
     <Datatable.Data>
-      {#each ledgerReports as report (report.id)}
+      <!-- TODO: remove this filter when BE filters out policy reports -->
+      {#each ledgerReports.filter((r) => !r.file?.name.includes('policy')) as report (report.id)}
         <Datatable.Data.Row on:click={() => $goto(reportDetails(report.id))} clickable>
           <Datatable.Data.Row.Item>{report.type || ''}</Datatable.Data.Row.Item>
           <Datatable.Data.Row.Item>{formatFriendlyDate(report.date)}</Datatable.Data.Row.Item>


### PR DESCRIPTION
- fix adding an empty row to Policy Report Table
- add a store so PolicyReports get updated automatically
- add a notice for when no report is available
- get all ledger reports and filter down by user/`file.name` to initialize policyLedgerReports (this will help cut down on users creating excess reports since they will persist)
![image](https://user-images.githubusercontent.com/70765247/159589768-20467967-4ade-47bc-8d87-0b5861149024.png)
