### PR TITLE
Remove labels claim form and fix bug

### DIFF
--- a/src/business-rules/claim-payout-amount.ts
+++ b/src/business-rules/claim-payout-amount.ts
@@ -45,10 +45,9 @@ export const isUnrepairableOrTooExpensive = (
 }
 
 export const isEvidenceNeeded = (claimItem: ClaimItem, claimStatus: ClaimStatus): boolean => {
-  const willNeedEvidence = claimItem.fmv > 0 || claimItem.repair_estimate > 0
-  const repairCostIsNotTooHigh = !isRepairCostTooHigh(claimItem.repair_estimate, claimItem.fmv)
+  const willNeedEvidence = [PayoutOption.FMV, PayoutOption.Repair].includes(claimItem.payout_option)
   const canProvideEvidenceNow = [ClaimStatus.Draft].includes(claimStatus)
-  return willNeedEvidence && repairCostIsNotTooHigh && canProvideEvidenceNow
+  return willNeedEvidence && canProvideEvidenceNow
 }
 
 export const getFilePurpose = (claimItem: ClaimItem, needsReceipt: boolean): ClaimFilePurpose | '' => {

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -230,7 +230,7 @@ const unSetReplaceEstimate = () => {
     </p>
     <p>
       <span class="header">What happened?</span>
-      <TextArea {maxlength} required label="Describe the situation" bind:value={situationDescription} rows="4" />
+      <TextArea {maxlength} required description="Describe the situation" bind:value={situationDescription} rows="4" />
     </p>
     {#if shouldAskIfRepairable}
       <div>
@@ -240,7 +240,8 @@ const unSetReplaceEstimate = () => {
 
     {#if isRepairable}
       <p>
-        <MoneyInput minValue={'0'} label="Repair estimate (USD)" bind:value={repairEstimateUSD} />
+        <span class="d-block mb-half">Repair estimate (USD)</span>
+        <MoneyInput minValue={'0'} bind:value={repairEstimateUSD} />
         <Description>
           How much will it probably cost to be repaired?
           <br />
@@ -249,7 +250,8 @@ const unSetReplaceEstimate = () => {
       </p>
       <p>
         <!-- If it's repairable, position this BEFORE the "Payout options" prompt. -->
-        <MoneyInput minValue={'0'} label="Fair market value (USD)" bind:value={fairMarketValueUSD} />
+        <span class="d-block mb-half">Fair market value (USD)</span>
+        <MoneyInput minValue={'0'} bind:value={fairMarketValueUSD} />
         <Description>
           <ConvertCurrencyLink />
         </Description>
@@ -263,7 +265,8 @@ const unSetReplaceEstimate = () => {
       </div>
       {#if payoutOption === PayoutOption.Replacement}
         <p>
-          <MoneyInput minValue={'0'} label="Replacement estimate (USD)" bind:value={replaceEstimateUSD} />
+          <span class="d-block mb-half">Replacement estimate (USD)</span>
+          <MoneyInput minValue={'0'} bind:value={replaceEstimateUSD} />
           <Description>
             How much will it probably cost to replace?
             <br />
@@ -276,7 +279,8 @@ const unSetReplaceEstimate = () => {
     {#if isRepairable === false && payoutOption === PayoutOption.FMV}
       <p>
         <!-- If we know it's not repairable, position this AFTER the "Payout options" prompt. -->
-        <MoneyInput minValue={'0'} label="Fair market value (USD)" bind:value={fairMarketValueUSD} />
+        <span class="d-block mb-half">Fair market value (USD)</span>
+        <MoneyInput minValue={'0'} bind:value={fairMarketValueUSD} />
         <Description>
           <ConvertCurrencyLink />
         </Description>

--- a/src/components/forms/ClaimForm.svelte
+++ b/src/components/forms/ClaimForm.svelte
@@ -250,7 +250,7 @@ const unSetReplaceEstimate = () => {
       </p>
       <p>
         <!-- If it's repairable, position this BEFORE the "Payout options" prompt. -->
-        <span class="flex justify-start">
+        <span class="flex justify-start align-items-center">
           <div>
             <span class="d-block mb-half">Fair market value (USD)</span>
             <MoneyInput minValue={'0'} bind:value={fairMarketValueUSD} />
@@ -284,7 +284,7 @@ const unSetReplaceEstimate = () => {
     {#if isRepairable === false && payoutOption === PayoutOption.FMV}
       <p>
         <!-- If we know it's not repairable, position this AFTER the "Payout options" prompt. -->
-        <span class="flex justify-start">
+        <span class="flex justify-start align-items-center">
           <div>
             <span class="d-block mb-half">Fair market value (USD)</span>
             <MoneyInput minValue={'0'} bind:value={fairMarketValueUSD} />

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -357,12 +357,8 @@ const isFileUploadedByPurpose = (purpose: ClaimFilePurpose, files: ClaimFile[]):
 
       {#if isMemberOfPolicy}
         {#if needsReceipt}
-          <MoneyInput
-            minValue={'0'}
-            bind:value={repairOrReplacementCost}
-            label={moneyFormLabel}
-            on:blur={onMoneyInputBlur}
-          />
+          <span class="d-block mb-half">{moneyFormLabel}</span>
+          <MoneyInput minValue={'0'} bind:value={repairOrReplacementCost} on:blur={onMoneyInputBlur} />
 
           <p class="label ml-1 mt-6px">
             <ConvertCurrencyLink />


### PR DESCRIPTION
- Stop using built in TextInput labels
- fix ClaimId view bug for FMV claims where repairable is selected but estimate is too high and unable to submit

![image](https://user-images.githubusercontent.com/70765247/160746733-45679b41-a17d-4f23-a290-2f7c32e83cc6.png)

![image](https://user-images.githubusercontent.com/70765247/160746794-b144ac7f-5f85-4814-9136-c76ded1d03b6.png)