### PR TITLE
Drawer was remaining invisible after login

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -26,7 +26,7 @@ const authenticateUser = async () => {
       }
     })
     .then(() => {
-      if ($user.policies?.length > 0) $showApp = true
+      if ($user.id) $showApp = true
     })
 }
 
@@ -44,7 +44,7 @@ $afterPageLoad((page: { path: string }) => {
 </svelte:head>
 
 <Router {routes} />
-
-<Snackbar />
-
+{#if $showApp}
+  <Snackbar />
+{/if}
 <FreshdeskWidget />


### PR DESCRIPTION
- I logged in after a `make fresh` and the Drawer remained invisible until I refreshed. The policy was probably just taking awhile.
- use `$user.id` instead of policies to check for authentication
- also hide the snackbar until after login so users don't see "you can't perform this action" while logging in