### PR TITLE
fix checkout duplicate item bug and button overlapping with freshdesk

### DIFF
--- a/src/components/Checkout.svelte
+++ b/src/components/Checkout.svelte
@@ -48,6 +48,10 @@ const handleDialog = (event: CustomEvent<string>) => {
   padding: 4px;
   border-radius: 8px 8px 0 0;
 }
+
+.agreement {
+  padding: 1rem 20% 1rem 1rem;
+}
 </style>
 
 <h2>Review Coverage and Checkout</h2>
@@ -70,7 +74,7 @@ const handleDialog = (event: CustomEvent<string>) => {
   >
 </div>
 
-<div class="flex align-items-center p-1">
+<div class="agreement flex align-items-center">
   <div>
     Pay {formatMoney(item.prorated_annual_premium)} for the remainder of {year} from {org} account {accountOrhouseholdId}.
     Auto-renew and pay {formatMoney(item.annual_premium)} on {renewDate}.

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -6,7 +6,7 @@ import { addItem, deleteItem, loadItems, PolicyItem, submitItem } from 'data/ite
 import { PolicyType, selectedPolicy, updatePolicy } from 'data/policies'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { HOME, items as itemsRoute, itemDetails, itemsNew } from 'helpers/routes'
+import { HOME, items as itemsRoute, itemDetails, itemsNew, itemEdit } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page, setNotice } from '@silintl/ui-components'
 import { onMount } from 'svelte'
@@ -56,7 +56,7 @@ const onDelete = async (event: CustomEvent<string>) => {
 }
 
 const onEdit = () => {
-  isCheckingOut = false
+  $goto(itemEdit(policyId, item.id))
 }
 
 const onClosed = async (event: CustomEvent<any>) => {


### PR DESCRIPTION
- adding 20% padding to the right of the checkout button to prevent total overlap with freshdesk button
- send to editItem so new item isn't created again