### PR TITLE
Preserve history on checkout

### DIFF
--- a/src/components/Checkout.svelte
+++ b/src/components/Checkout.svelte
@@ -10,13 +10,13 @@ import { goto } from '@roxi/routify'
 import { Button, Checkbox } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
-export let item: PolicyItem
+export let item = {} as PolicyItem
 export let policyId: string
 
 let open: boolean = false
 let checked: boolean = false
 
-$: itemId = item?.id
+$: itemId = item.id
 
 $: policy = $selectedPolicy
 $: householdId = policy.household_id || ''

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -110,7 +110,8 @@ const validateOnSave = (formData: any) => {
 const validate = (formData: any) => {
   validateOnSave(formData)
   assertHas(formData.marketValueUSD, 'Please specify the market value')
-  assertIsLessOrEqual(formData.marketValueUSD * 100, item.coverage_amount, 'Coverage amount cannot be increased')
+  item.coverage_status !== ItemCoverageStatus.Draft &&
+    assertIsLessOrEqual(formData.marketValueUSD * 100, item.coverage_amount, 'Coverage amount cannot be increased')
   return true
 }
 

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -22,7 +22,7 @@ export const FAQ = '/faq'
 export const ITEMS = '/items'
 export const items = (policyId: string) => `/policies/${policyId}/items`
 export const itemsNew = (policyId: string) => `/policies/${policyId}/items/new`
-export const itemsCheckout = (policyId: string, ItemId: string) => `/policies/${policyId}/items/${ItemId}/checkout`
+export const itemsCheckout = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/checkout`
 export const itemDetails = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}`
 export const itemEdit = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/edit`
 export const itemNewClaim = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/new-claim`

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -22,6 +22,7 @@ export const FAQ = '/faq'
 export const ITEMS = '/items'
 export const items = (policyId: string) => `/policies/${policyId}/items`
 export const itemsNew = (policyId: string) => `/policies/${policyId}/items/new`
+export const itemsCheckout = (policyId: string, ItemId: string) => `/policies/${policyId}/items/${ItemId}/checkout`
 export const itemDetails = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}`
 export const itemEdit = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/edit`
 export const itemNewClaim = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/new-claim`

--- a/src/pages/policies/[policyId]/items/[itemId]/checkout.svelte
+++ b/src/pages/policies/[policyId]/items/[itemId]/checkout.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import Checkout from 'Checkout.svelte'
+import { deleteItem, loadItems, PolicyItem, selectedPolicyItems, submitItem } from 'data/items'
+import { selectedPolicyId } from 'data/role-policy-selection'
+import { formatPageTitle } from 'helpers/pageTitle'
+import { itemDetails, items, itemEdit } from 'helpers/routes'
+import { goto, metatags } from '@roxi/routify'
+import { Page } from '@silintl/ui-components'
+import { onMount } from 'svelte'
+
+export let itemId: string
+
+onMount(() => {
+  loadItems(policyId)
+})
+
+$: policyId = $selectedPolicyId
+$: item = $selectedPolicyItems.find((i) => i.id === itemId) as PolicyItem
+$: metatags.title = formatPageTitle('Items > Checkout')
+
+const onEdit = () => {
+  $goto(itemEdit(policyId, itemId))
+}
+
+const onDelete = async (event: CustomEvent<string>) => {
+  await deleteItem(policyId, event.detail)
+  $goto(items(policyId))
+}
+
+const onAgreeAndPay = async (event: CustomEvent<string>) => {
+  const itemId = event.detail
+  await submitItem(itemId)
+  $goto(itemDetails(policyId, itemId))
+}
+</script>
+
+<Page>
+  <Checkout {item} {policyId} on:agreeAndPay={onAgreeAndPay} on:delete={onDelete} on:edit={onEdit} />
+</Page>

--- a/src/pages/policies/[policyId]/items/[itemId]/edit.svelte
+++ b/src/pages/policies/[policyId]/items/[itemId]/edit.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import Checkout from 'Checkout.svelte'
 import { Breadcrumb, ItemBanner, ItemForm } from 'components'
 import { loading } from 'components/progress'
 import { loadDependents } from 'data/dependents'
@@ -15,15 +14,13 @@ import {
 } from 'data/items'
 import { selectedPolicyId } from 'data/role-policy-selection'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { HOME, items as itemsRoute, itemDetails, itemEdit } from 'helpers/routes'
+import { HOME, items as itemsRoute, itemDetails, itemEdit, itemsCheckout } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
 
 export let itemId: string
 export let policyId = $selectedPolicyId
-
-let isCheckingOut: boolean = false
 
 onMount(() => {
   loadDependents(policyId)
@@ -45,7 +42,7 @@ $: itemName && (metatags.title = formatPageTitle(`Items > ${itemName} > Edit`))
 const onApply = async (event: CustomEvent) => {
   await updateItem(policyId, itemId, event.detail)
   if (item.coverage_status === ItemCoverageStatus.Draft) {
-    isCheckingOut = true
+    $goto(itemsCheckout(policyId, item.id))
   } else {
     if (item.coverage_status === ItemCoverageStatus.Revision) {
       await submitItem(itemId)
@@ -57,23 +54,13 @@ const onApply = async (event: CustomEvent) => {
 const onSaveForLater = async (event: CustomEvent) => {
   await updateItem(policyId, itemId, event.detail)
 
-  $goto(HOME)
+  event.detail.isAutoSaving || $goto(HOME)
 }
 
 const onDelete = async () => {
   await deleteItem(policyId, itemId)
 
   $goto(HOME)
-}
-
-const onAgreeAndPay = async (event: CustomEvent<string>) => {
-  const itemId = event.detail
-  await submitItem(itemId)
-  $goto(itemDetails(policyId, itemId))
-}
-
-const onEdit = () => {
-  isCheckingOut = false
 }
 </script>
 
@@ -83,8 +70,6 @@ const onEdit = () => {
   {:else}
     We could not find that item. Please <a href={itemsRoute(policyId)}>go back</a> and select an item from the list.
   {/if}
-{:else if isCheckingOut}
-  <Checkout {item} {policyId} on:agreeAndPay={onAgreeAndPay} on:delete={onDelete} on:edit={onEdit} />
 {:else}
   <!-- @todo Handle situations where the user isn't allowed to edit this item (if any). -->
   <Page>

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Breadcrumb, ItemForm, NoHouseholdIdModal } from 'components'
 import { loadDependents } from 'data/dependents'
-import { addItem, loadItems, PolicyItem } from 'data/items'
+import { addItem, loadItems, PolicyItem, updateItem } from 'data/items'
 import { PolicyType, selectedPolicy, updatePolicy } from 'data/policies'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -12,7 +12,7 @@ import { onMount } from 'svelte'
 
 export let policyId: string
 
-let item: PolicyItem
+let item = {} as PolicyItem
 let open = false
 
 onMount(() => {
@@ -37,7 +37,7 @@ const onApply = async (event: CustomEvent) => {
 }
 
 const onSaveForLater = async (event: CustomEvent) => {
-  item = await addItem(policyId, event.detail)
+  item.id ? await updateItem(policyId, item.id, event.detail) : (item = await addItem(policyId, event.detail))
 
   if (event.detail.isAutoSaving) {
     //Todo once autosaving can happen on an empty form send the user immediately to edit.

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -5,7 +5,7 @@ import { addItem, loadItems, PolicyItem } from 'data/items'
 import { PolicyType, selectedPolicy, updatePolicy } from 'data/policies'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { HOME, items as itemsRoute, itemsCheckout, itemsNew } from 'helpers/routes'
+import { HOME, items as itemsRoute, itemsCheckout, itemEdit, itemsNew } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page, setNotice } from '@silintl/ui-components'
 import { onMount } from 'svelte'
@@ -37,9 +37,9 @@ const onApply = async (event: CustomEvent) => {
 }
 
 const onSaveForLater = async (event: CustomEvent) => {
-  await addItem(policyId, event.detail)
+  item = await addItem(policyId, event.detail)
 
-  $goto(HOME)
+  event.detail.isAutoSaving ? $goto(itemEdit(policyId, item.id)) : $goto(HOME)
 }
 
 const onClosed = async (event: CustomEvent<any>) => {

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-import Checkout from 'Checkout.svelte'
 import { Breadcrumb, ItemForm, NoHouseholdIdModal } from 'components'
 import { loadDependents } from 'data/dependents'
-import { addItem, deleteItem, loadItems, PolicyItem, submitItem } from 'data/items'
+import { addItem, loadItems, PolicyItem } from 'data/items'
 import { PolicyType, selectedPolicy, updatePolicy } from 'data/policies'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { HOME, items as itemsRoute, itemDetails, itemsNew } from 'helpers/routes'
+import { HOME, items as itemsRoute, itemsCheckout, itemsNew } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
 import { Page, setNotice } from '@silintl/ui-components'
 import { onMount } from 'svelte'
 
 export let policyId: string
 
-let isCheckingOut = false
 let item: PolicyItem
 let open = false
 
@@ -35,28 +33,13 @@ $: breadcrumbLinks = [
 
 const onApply = async (event: CustomEvent) => {
   item = await addItem(policyId, event.detail)
-  isCheckingOut = true
+  $goto(itemsCheckout(policyId, item.id))
 }
 
 const onSaveForLater = async (event: CustomEvent) => {
   await addItem(policyId, event.detail)
 
   $goto(HOME)
-}
-
-const onAgreeAndPay = async (event: CustomEvent<string>) => {
-  const itemId = event.detail
-  await submitItem(itemId)
-  $goto(itemDetails(policyId, itemId))
-}
-
-const onDelete = async (event: CustomEvent<string>) => {
-  await deleteItem(policyId, event.detail)
-  $goto(itemsRoute(policyId))
-}
-
-const onEdit = () => {
-  isCheckingOut = false
 }
 
 const onClosed = async (event: CustomEvent<any>) => {
@@ -72,11 +55,7 @@ const onClosed = async (event: CustomEvent<any>) => {
 </script>
 
 <Page>
-  {#if !isCheckingOut}
-    <Breadcrumb links={breadcrumbLinks} />
-    <ItemForm {item} {policyId} on:submit={onApply} on:save-for-later={onSaveForLater} />
-    <NoHouseholdIdModal {open} on:closed={onClosed} />
-  {:else}
-    <Checkout {item} {policyId} on:agreeAndPay={onAgreeAndPay} on:delete={onDelete} on:edit={onEdit} />
-  {/if}
+  <Breadcrumb links={breadcrumbLinks} />
+  <ItemForm {item} {policyId} on:submit={onApply} on:save-for-later={onSaveForLater} />
+  <NoHouseholdIdModal {open} on:closed={onClosed} />
 </Page>

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -39,7 +39,12 @@ const onApply = async (event: CustomEvent) => {
 const onSaveForLater = async (event: CustomEvent) => {
   item = await addItem(policyId, event.detail)
 
-  event.detail.isAutoSaving ? $goto(itemEdit(policyId, item.id)) : $goto(HOME)
+  if (event.detail.isAutoSaving) {
+    //Todo once autosaving can happen on an empty form send the user immediately to edit.
+    // $goto(itemEdit(policyId, item.id))
+  } else {
+    $goto(HOME)
+  }
 }
 
 const onClosed = async (event: CustomEvent<any>) => {


### PR DESCRIPTION
- Make checkout its own page to preserve history
- add autosaving to ItemForm with debounce
- new -> edit on ItemForm autosave so when user click 🔙  they go to edit with data preserved

some notes:
when creating a new item once category and name are filled out and 4 sec of inactivity the user is taking to edit, but page scroll and focus are not preserved in ItemForm. Is there a way around this?

I failed to capture clicking the back button in the frame and that the form does indeed start on new.
![preserve-history](https://user-images.githubusercontent.com/70765247/165680696-198fd213-d7d9-475c-971a-0f28e48b0511.gif)

