### PR TITLE
add RemoveMemberModal

### DIFF
--- a/src/components/RemoveDependentModal.svelte
+++ b/src/components/RemoveDependentModal.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
+import type { PolicyDependent } from 'data/dependents'
 import { howManyItemsAccountablePersonIsOn } from 'data/items'
-import { createEventDispatcher, onMount } from 'svelte'
 import { Dialog } from '@silintl/ui-components'
+import { createEventDispatcher } from 'svelte'
 
 export let open: boolean = false
-export let dependentId: string
+export let dependent = {} as PolicyDependent
 export let policyId: string = ''
 
-let dependentIsOnItems: boolean = false
+let numberOfItemsDependentIsOn = 0
 
-onMount(() => {
-  dependentIsOnItems = !!howManyItemsAccountablePersonIsOn(dependentId, policyId)
-})
+$: numberOfItemsDependentIsOn = howManyItemsAccountablePersonIsOn(dependent.id, policyId)
 
 const title = 'Remove Dependent'
 const buttonsWithoutItems: Dialog.AlertButton[] = [
@@ -22,8 +21,8 @@ const buttonsWithItems: Dialog.AlertButton[] = [
   { label: 'cancel', action: 'cancel', class: 'mdc-dialog__button' },
   { label: 'Items', action: 'gotoItems', class: 'error-button' },
 ]
-$: buttons = dependentIsOnItems ? buttonsWithItems : buttonsWithoutItems
-$: message = dependentIsOnItems
+$: buttons = !!numberOfItemsDependentIsOn ? buttonsWithItems : buttonsWithoutItems
+$: message = !!numberOfItemsDependentIsOn
   ? `Please remove this dependent from all items before removing.`
   : `Permanently remove this dependent?`
 
@@ -35,5 +34,8 @@ const handleDialog = (e: CustomEvent) => {
 </script>
 
 <Dialog.Alert {open} {buttons} defaultAction="cancel" {title} on:closed={handleDialog} on:chosen={handleDialog}>
+  {dependent.name} is accountable for {numberOfItemsDependentIsOn}
+  {numberOfItemsDependentIsOn === 1 ? 'item' : 'items'}.
+
   {message}
 </Dialog.Alert>

--- a/src/components/RemoveMemberModal.svelte
+++ b/src/components/RemoveMemberModal.svelte
@@ -24,7 +24,7 @@ const buttonsWithItems: Dialog.AlertButton[] = [
 $: buttons = !!numberOfItemsDependentIsOn ? buttonsWithItems : buttonsWithoutItems
 $: message = !!numberOfItemsDependentIsOn
   ? `Please remove this person from all items before removing.`
-  : `Permanently remove this person?`
+  : `Permanently remove this person? This cannot be undone.`
 
 const dispatch = createEventDispatcher<{ remove: string; cancel: string; gotoItems: string; closed: string }>()
 

--- a/src/components/RemoveMemberModal.svelte
+++ b/src/components/RemoveMemberModal.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
 import { howManyItemsAccountablePersonIsOn } from 'data/items'
-import { createEventDispatcher, onMount } from 'svelte'
 import { Dialog } from '@silintl/ui-components'
+import type { PolicyMember } from 'data/types/policy-members'
+import { createEventDispatcher } from 'svelte'
 
 export let open: boolean = false
-export let dependentId: string
+export let policyMember = {} as PolicyMember
 export let policyId: string = ''
 
-let dependentIsOnItems: boolean = false
+let numberOfItemsDependentIsOn: number
 
-onMount(() => {
-  dependentIsOnItems = !!howManyItemsAccountablePersonIsOn(dependentId, policyId)
-})
+$: numberOfItemsDependentIsOn = howManyItemsAccountablePersonIsOn(policyMember.id, policyId)
 
-const title = 'Remove Dependent'
+const title = 'Remove Person'
 const buttonsWithoutItems: Dialog.AlertButton[] = [
   { label: 'cancel', action: 'cancel', class: 'mdc-dialog__button' },
   { label: 'Remove', action: 'remove', class: 'error-button' },
@@ -22,10 +21,10 @@ const buttonsWithItems: Dialog.AlertButton[] = [
   { label: 'cancel', action: 'cancel', class: 'mdc-dialog__button' },
   { label: 'Items', action: 'gotoItems', class: 'error-button' },
 ]
-$: buttons = dependentIsOnItems ? buttonsWithItems : buttonsWithoutItems
-$: message = dependentIsOnItems
-  ? `Please remove this dependent from all items before removing.`
-  : `Permanently remove this dependent?`
+$: buttons = numberOfItemsDependentIsOn ? buttonsWithItems : buttonsWithoutItems
+$: message = numberOfItemsDependentIsOn
+  ? `Please remove this person from all items before removing.`
+  : `Permanently remove this person?`
 
 const dispatch = createEventDispatcher<{ remove: string; cancel: string; gotoItems: string; closed: string }>()
 
@@ -35,5 +34,8 @@ const handleDialog = (e: CustomEvent) => {
 </script>
 
 <Dialog.Alert {open} {buttons} defaultAction="cancel" {title} on:closed={handleDialog} on:chosen={handleDialog}>
+  {policyMember.first_name} is accountable for {numberOfItemsDependentIsOn}
+  {numberOfItemsDependentIsOn > 1 ? 'items' : 'item'}.
+
   {message}
 </Dialog.Alert>

--- a/src/components/RemoveMemberModal.svelte
+++ b/src/components/RemoveMemberModal.svelte
@@ -35,7 +35,7 @@ const handleDialog = (e: CustomEvent) => {
 
 <Dialog.Alert {open} {buttons} defaultAction="cancel" {title} on:closed={handleDialog} on:chosen={handleDialog}>
   {policyMember.first_name} is accountable for {numberOfItemsDependentIsOn}
-  {numberOfItemsDependentIsOn > 1 ? 'items' : 'item'}.
+  {numberOfItemsDependentIsOn === 1 ? 'item' : 'items'}.
 
   {message}
 </Dialog.Alert>

--- a/src/components/RemoveMemberModal.svelte
+++ b/src/components/RemoveMemberModal.svelte
@@ -8,7 +8,7 @@ export let open: boolean = false
 export let policyMember = {} as PolicyMember
 export let policyId: string = ''
 
-let numberOfItemsDependentIsOn: number
+let numberOfItemsDependentIsOn = 0
 
 $: numberOfItemsDependentIsOn = howManyItemsAccountablePersonIsOn(policyMember.id, policyId)
 
@@ -21,8 +21,8 @@ const buttonsWithItems: Dialog.AlertButton[] = [
   { label: 'cancel', action: 'cancel', class: 'mdc-dialog__button' },
   { label: 'Items', action: 'gotoItems', class: 'error-button' },
 ]
-$: buttons = numberOfItemsDependentIsOn ? buttonsWithItems : buttonsWithoutItems
-$: message = numberOfItemsDependentIsOn
+$: buttons = !!numberOfItemsDependentIsOn ? buttonsWithItems : buttonsWithoutItems
+$: message = !!numberOfItemsDependentIsOn
   ? `Please remove this person from all items before removing.`
   : `Permanently remove this person?`
 

--- a/src/components/forms/DependentForm.svelte
+++ b/src/components/forms/DependentForm.svelte
@@ -206,7 +206,7 @@ const onChosen = (event: CustomEvent) => (formData.country = event.detail)
   </Form>
 
   <RemoveDependentModal
-    dependentId={dependent.id}
+    {dependent}
     {policyId}
     open={removeModalIsOpen}
     on:remove={onRemove}

--- a/src/components/forms/DependentForm.svelte
+++ b/src/components/forms/DependentForm.svelte
@@ -13,8 +13,8 @@ export type DependentFormData = {
 
 <script lang="ts">
 import RadioOptions from '../RadioOptions.svelte'
-import CountrySelector from '../components/CountrySelector.svelte'
-import RemoveDependentModal from '../components/RemoveDependentModal.svelte'
+import CountrySelector from '../CountrySelector.svelte'
+import RemoveDependentModal from '../RemoveDependentModal.svelte'
 import { MAX_INPUT_LENGTH as maxlength, MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { PolicyDependent } from 'data/dependents'
 import { ITEMS } from 'helpers/routes'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -36,6 +36,7 @@ import MessageBanner from './banners/MessageBanner.svelte'
 import SearchableSelect from './SearchableSelect.svelte'
 import RemoveProfilePicModal from './RemoveProfilePicModal.svelte'
 import RemoveDependentModal from './RemoveDependentModal.svelte'
+import RemoveMemberModal from './RemoveMemberModal.svelte'
 import RevokeModal from './RevokeModal.svelte'
 import Strikes from './Strikes.svelte'
 
@@ -78,6 +79,7 @@ export {
   MessageBanner,
   RemoveProfilePicModal,
   RemoveDependentModal,
+  RemoveMemberModal,
   RevokeModal,
   Strikes,
 }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -272,8 +272,8 @@ export async function deleteItem(policyId: string, itemId: string): Promise<any>
 
 export const itemBelongsToPolicy = (policyId: string, item: PolicyItem): boolean => item.policy_id === policyId
 
-export const isDependentOnItemsByPolicyId = (dependentId: string, policyId: string): boolean => {
-  return get(itemsByPolicyId)[policyId]?.some((item) => item.accountable_person?.id === dependentId)
+export const howManyItemsAccountablePersonIsOn = (dependentId: string, policyId: string): number => {
+  return get(itemsByPolicyId)[policyId]?.filter((item) => item.accountable_person?.id === dependentId)?.length
 }
 
 function updateStoreItem(updatedItem: PolicyItem) {

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -273,7 +273,7 @@ export async function deleteItem(policyId: string, itemId: string): Promise<any>
 export const itemBelongsToPolicy = (policyId: string, item: PolicyItem): boolean => item.policy_id === policyId
 
 export const howManyItemsAccountablePersonIsOn = (dependentId: string, policyId: string): number => {
-  return get(itemsByPolicyId)[policyId]?.filter((item) => item.accountable_person?.id === dependentId)?.length
+  return get(itemsByPolicyId)[policyId]?.filter((item) => item.accountable_person?.id === dependentId).length
 }
 
 function updateStoreItem(updatedItem: PolicyItem) {

--- a/src/data/policy-members.ts
+++ b/src/data/policy-members.ts
@@ -1,4 +1,4 @@
-import { GET, CREATE as POST } from './index'
+import { GET, CREATE as POST, DELETE } from './index'
 import { loadPolicy } from './policies'
 import { selectedPolicyId } from './role-policy-selection'
 import type { PolicyMember } from './types/policy-members'
@@ -45,4 +45,19 @@ export async function invitePolicyMember(
     inviter_message: message,
   })
   loadPolicy(policyId)
+}
+export async function deletePolicyMember(policyMemberId: string): Promise<void> {
+  await DELETE<void>(`policy-members/${policyMemberId}`)
+
+  membersByPolicyId.update((data) => {
+    const entries = Object.entries(data)
+    const entryWithMemberToDelete = entries.find((entry) => entry[1].find((member) => member.id === policyMemberId))
+    const policyId = entryWithMemberToDelete?.[0]
+    const memberToDelete = entryWithMemberToDelete?.[1].find((member) => member.id === policyMemberId)
+    const memberId = memberToDelete?.id
+    if (policyId) {
+      data[policyId] = data[policyId].filter((member) => member.id !== memberId)
+    }
+    return data
+  })
 }

--- a/src/data/policy-members.ts
+++ b/src/data/policy-members.ts
@@ -51,9 +51,11 @@ export async function deletePolicyMember(policyMemberId: string): Promise<void> 
 
   membersByPolicyId.update((data) => {
     const entries = Object.entries(data)
-    const entryWithMemberToDelete = entries.find((entry) => entry[1].some((member) => member.id === policyMemberId))
+    const entryWithMemberToDelete = entries.find((entry) =>
+      entry[1].some((member) => member.policy_user_id === policyMemberId)
+    )
     const policyId = entryWithMemberToDelete?.[0]
-    const memberToDelete = entryWithMemberToDelete?.[1].find((member) => member.id === policyMemberId)
+    const memberToDelete = entryWithMemberToDelete?.[1].find((member) => member.policy_user_id === policyMemberId)
     const memberId = memberToDelete?.id
     if (policyId) {
       data[policyId] = data[policyId].filter((member) => member.id !== memberId)

--- a/src/data/policy-members.ts
+++ b/src/data/policy-members.ts
@@ -51,7 +51,7 @@ export async function deletePolicyMember(policyMemberId: string): Promise<void> 
 
   membersByPolicyId.update((data) => {
     const entries = Object.entries(data)
-    const entryWithMemberToDelete = entries.find((entry) => entry[1].find((member) => member.id === policyMemberId))
+    const entryWithMemberToDelete = entries.find((entry) => entry[1].some((member) => member.id === policyMemberId))
     const policyId = entryWithMemberToDelete?.[0]
     const memberToDelete = entryWithMemberToDelete?.[1].find((member) => member.id === policyMemberId)
     const memberId = memberToDelete?.id

--- a/src/data/types/policy-members.ts
+++ b/src/data/types/policy-members.ts
@@ -6,4 +6,5 @@ export type PolicyMember = {
   last_login_utc: string /*Date*/
   last_name: string
   country: string
+  policy_user_id: string
 }

--- a/src/pages/policies/[policyId]/settings.svelte
+++ b/src/pages/policies/[policyId]/settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import user, { isAdmin } from 'data/user'
-import { Breadcrumb, Description, SearchableSelect, DependentForm } from 'components'
+import { Breadcrumb, Description, SearchableSelect, DependentForm, RemoveMemberModal } from 'components'
 import { MAX_INPUT_LENGTH as maxlength } from 'components/const'
 import type { DependentFormData } from 'components/forms/DependentForm.svelte'
 import {
@@ -14,10 +14,10 @@ import {
 import { entityCodes, loadEntityCodes } from 'data/entityCodes'
 import { loadItems } from 'data/items'
 import { updatePolicy, Policy, PolicyType, loadPolicy, selectedPolicy } from 'data/policies'
-import { invitePolicyMember, loadMembersOfPolicy, selectedPolicyMembers } from 'data/policy-members'
+import { deletePolicyMember, invitePolicyMember, loadMembersOfPolicy, selectedPolicyMembers } from 'data/policy-members'
 import { roleSelection, selectedPolicyId } from 'data/role-policy-selection'
 import type { PolicyMember } from 'data/types/policy-members'
-import { POLICIES, policyDetails, settingsPolicy, SETTINGS_PERSONAL } from 'helpers/routes'
+import { ITEMS, POLICIES, policyDetails, settingsPolicy, SETTINGS_PERSONAL } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { goto, metatags } from '@roxi/routify'
 import { Button, TextField, IconButton, Page, setNotice, Tooltip, Dialog } from '@silintl/ui-components'
@@ -40,6 +40,8 @@ let placeholder = 'Your entity of affiliation'
 let modalData: PolicyDependent
 let showAddDependentModal = false
 let modalTitle = 'Add Person'
+let removeModalIsOpen = false
+let selectedPolicyMember: PolicyMember
 
 $: breadcrumbLinks = isAdmin($roleSelection)
   ? [
@@ -208,6 +210,8 @@ const editDependent = (dependent: PolicyDependent) => {
   modalData = dependent
   showAddDependentModal = true
 }
+
+const onRemove = (policyUserId: string) => deletePolicyMember(policyUserId)
 </script>
 
 <style>
@@ -314,6 +318,14 @@ p {
             </Tooltip.Wrapper>
 
             <Tooltip tooltipID={'edit-person-' + policyMember.id} positionX="end">Edit Person</Tooltip> -->
+            <IconButton
+              icon="delete"
+              ariaLabel="Delete"
+              on:click={() => {
+                selectedPolicyMember = policyMember
+                removeModalIsOpen = true
+              }}
+            />
           {/if}
         </span>
       </li>
@@ -380,4 +392,14 @@ p {
       />
     {/if}
   </Dialog.Alert>
+
+  <RemoveMemberModal
+    policyMember={selectedPolicyMember}
+    {policyId}
+    open={removeModalIsOpen}
+    on:remove={() => onRemove(selectedPolicyMember.policy_user_id)}
+    on:gotoItems={() => $goto(ITEMS)}
+    on:cancel={() => (removeModalIsOpen = false)}
+    on:closed={() => (removeModalIsOpen = false)}
+  />
 </Page>


### PR DESCRIPTION
- added a basic modal for removing a member (similar to dependents modal)
- changed isDependentOnItemsByPolicyId to howManyItemsAccountablePersonIsOn
- fixed some imports
- added a delete button for policy-members in settings (excluding self)
![image](https://user-images.githubusercontent.com/70765247/166407175-b4619437-51bd-4879-9e9d-5a3e7ea8d248.png)
![remove-member](https://user-images.githubusercontent.com/70765247/166834430-32887c4d-3458-4586-acbd-d0dc07b57490.gif)
