### PR TITLE
preserve new item data with qs

### DIFF
--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -7,7 +7,7 @@ import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import SelectAccountablePerson from '../SelectAccountablePerson.svelte'
 import { MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
-import { ItemCoverageStatus, PolicyItem } from 'data/items'
+import { ItemCoverageStatus, NewItemFormData, PolicyItem, SaveFormData } from 'data/items'
 import { categories, loadCategories, initialized as catItemsInitialized } from 'data/itemCategories'
 import TextFieldWithLabel from '../TextFieldWithLabel.svelte'
 import { assertHas, assertIsLessOrEqual } from '../../validation/assertions'
@@ -19,12 +19,12 @@ export let item = {} as PolicyItem
 export let policyId: string
 
 let applyBtnLabel = ''
-let formData = {} as any
+let formData = {} as NewItemFormData
 let open = false
 let makeModelIsOpen = false
 let selectedAccountablePersonId: string
 
-const dispatch = createEventDispatcher<{ submit: any; 'save-for-later': any; delete: any }>()
+const dispatch = createEventDispatcher<{ submit: NewItemFormData; 'save-for-later': SaveFormData; delete: any }>()
 
 // Set default values.
 let accountablePersonId = ''
@@ -70,7 +70,7 @@ const onSelectCategory = (event: any) => {
   categoryId = event.detail?.id
 }
 
-const getFormData = () => {
+const getFormData = (): NewItemFormData => {
   return {
     accountablePersonId,
     categoryId,

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -7,7 +7,7 @@ import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import SelectAccountablePerson from '../SelectAccountablePerson.svelte'
 import { MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
-import { ItemCoverageStatus, NewItemFormData, PolicyItem, SaveFormData } from 'data/items'
+import { ItemCoverageStatus, NewItemFormData, PolicyItem, UpdateItemFormData } from 'data/items'
 import { categories, loadCategories, initialized as catItemsInitialized } from 'data/itemCategories'
 import TextFieldWithLabel from '../TextFieldWithLabel.svelte'
 import { assertHas, assertIsLessOrEqual } from '../../validation/assertions'
@@ -24,7 +24,7 @@ let open = false
 let makeModelIsOpen = false
 let selectedAccountablePersonId: string
 
-const dispatch = createEventDispatcher<{ submit: NewItemFormData; 'save-for-later': SaveFormData; delete: any }>()
+const dispatch = createEventDispatcher<{ submit: NewItemFormData; 'save-for-later': UpdateItemFormData; delete: any }>()
 
 // Set default values.
 let accountablePersonId = ''

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -24,7 +24,11 @@ let open = false
 let makeModelIsOpen = false
 let selectedAccountablePersonId: string
 
-const dispatch = createEventDispatcher<{ submit: NewItemFormData; 'save-for-later': UpdateItemFormData; delete: any }>()
+const dispatch = createEventDispatcher<{
+  submit: NewItemFormData | UpdateItemFormData
+  'save-for-later': UpdateItemFormData
+  delete: any
+}>()
 
 // Set default values.
 let accountablePersonId = ''

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ import AppFooter from './AppFooter.svelte'
 import Banner from './Banner.svelte'
 import Breadcrumb from './Breadcrumb.svelte'
 import CardsGrid from './CardsGrid.svelte'
+import Checkout from './Checkout.svelte'
 import ClaimActions from './ClaimActions.svelte'
 import ClaimCard from './ClaimCard.svelte'
 import ClaimCards from './ClaimCards.svelte'
@@ -45,6 +46,7 @@ export {
   AppFooter,
   Banner,
   Breadcrumb,
+  Checkout,
   ClaimActions,
   ClaimForm,
   ClaimsTable,

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -113,7 +113,7 @@ export interface NewItemFormData extends ItemFormData {
   coverageStatus?: ItemCoverageStatus
 }
 
-export interface SaveFormData extends ItemFormData {
+export interface UpdateItemFormData extends ItemFormData {
   isAutoSaving?: boolean
 }
 

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -241,7 +241,11 @@ export async function submitItem(itemId: string): Promise<void> {
  * @param {Object} itemData
  * @return {Object}
  */
-export async function updateItem(policyId: string, itemId: string, itemData: ItemFormData): Promise<void> {
+export async function updateItem(
+  policyId: string,
+  itemId: string,
+  itemData: ItemFormData | UpdateItemFormData
+): Promise<void> {
   if (!itemId) {
     throwError('item id not set')
   }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -66,31 +66,55 @@ export type PolicyItem = {
 export type CreatePolicyItemRequestBody = {
   accountable_person_id: string /*UUID*/
   category_id: string
-  country: string
-  coverage_amount: number
+  country?: string
+  coverage_amount?: number
   coverage_start_date: string /*Date*/
-  coverage_status: ItemCoverageStatus
-  description: string
-  in_storage: boolean
-  make: string
-  model: string
+  coverage_status?: ItemCoverageStatus
+  description?: string
+  in_storage?: boolean
+  make?: string
+  model?: string
   name: string
   risk_category_id?: string
-  serial_number: string
+  serial_number?: string
 }
 
 export type UpdatePolicyItemRequestBody = {
   accountable_person_id: string /*UUID*/
   category_id: string
-  country: string
-  coverage_amount: number
-  description: string
-  in_storage: boolean
-  make: string
-  model: string
+  country?: string
+  coverage_amount?: number
+  description?: string
+  in_storage?: boolean
+  make?: string
+  model?: string
   name: string
   risk_category_id?: string
-  serial_number: string
+  serial_number?: string
+}
+
+export interface ItemFormData {
+  accountablePersonId: string /*UUID*/
+  categoryId: string
+  country?: string
+  marketValueUSD?: number | string
+  itemDescription?: string
+  inStorage?: boolean
+  make?: string
+  model?: string
+  riskCategoryId?: string
+  name: string
+  uniqueIdentifier?: string
+}
+
+export interface NewItemFormData extends ItemFormData {
+  coverageStartDate: string /*Date*/
+  coverageEndDate?: string /*Date*/
+  coverageStatus?: ItemCoverageStatus
+}
+
+export interface SaveFormData extends ItemFormData {
+  isAutoSaving?: boolean
 }
 
 export const itemsByPolicyId = writable<{ [policyId: string]: PolicyItem[] }>({})
@@ -130,7 +154,7 @@ export async function loadItems(policyId: string): Promise<void> {
  * @param {Object} itemData
  * @return {Object}
  */
-export async function addItem(policyId: string, itemData: any): Promise<PolicyItem> {
+export async function addItem(policyId: string, itemData: NewItemFormData): Promise<PolicyItem> {
   const urlPath = `policies/${policyId}/items`
 
   const parsedItemData: CreatePolicyItemRequestBody = {
@@ -217,7 +241,7 @@ export async function submitItem(itemId: string): Promise<void> {
  * @param {Object} itemData
  * @return {Object}
  */
-export async function updateItem(policyId: string, itemId: string, itemData: any): Promise<void> {
+export async function updateItem(policyId: string, itemId: string, itemData: ItemFormData): Promise<void> {
   if (!itemId) {
     throwError('item id not set')
   }

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -23,8 +23,8 @@ export const FAQ = '/faq'
 export const ITEMS = '/items'
 export const items = (policyId: string) => `/policies/${policyId}/items`
 export const itemsNew = (policyId: string) => `/policies/${policyId}/items/new`
-export const itemsNewQs = (policyId: string, query: { itemId: string }) =>
-  `/policies/${policyId}/items/new?${qs.stringify(query)}`
+export const itemsNewQs = (policyId: string, itemId: string) =>
+  `/policies/${policyId}/items/new?${qs.stringify({ itemId })}`
 export const itemsCheckout = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/checkout`
 export const itemDetails = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}`
 export const itemEdit = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/edit`

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -22,6 +22,7 @@ export const FAQ = '/faq'
 export const ITEMS = '/items'
 export const items = (policyId: string) => `/policies/${policyId}/items`
 export const itemsNew = (policyId: string) => `/policies/${policyId}/items/new`
+export const itemsNewId = (policyId: string, query: string) => `/policies/${policyId}/items/new?${query}`
 export const itemsCheckout = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/checkout`
 export const itemDetails = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}`
 export const itemEdit = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/edit`

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import qs from 'qs'
 
 export const ROOT = '/'
 export const HOME = '/home'
@@ -22,7 +23,8 @@ export const FAQ = '/faq'
 export const ITEMS = '/items'
 export const items = (policyId: string) => `/policies/${policyId}/items`
 export const itemsNew = (policyId: string) => `/policies/${policyId}/items/new`
-export const itemsNewId = (policyId: string, query: string) => `/policies/${policyId}/items/new?${query}`
+export const itemsNewQs = (policyId: string, query: { itemId: string }) =>
+  `/policies/${policyId}/items/new?${qs.stringify(query)}`
 export const itemsCheckout = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/checkout`
 export const itemDetails = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}`
 export const itemEdit = (policyId: string, itemId: string) => `/policies/${policyId}/items/${itemId}/edit`

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -12,7 +12,7 @@ import {
   deleteItems,
 } from 'data/items'
 import { getNameOfPolicy, loadPolicy, Policy, PolicyType, selectedPolicy } from 'data/policies'
-import { roleSelection } from 'data/role-policy-selection'
+import { roleSelection, selectedPolicyId } from 'data/role-policy-selection'
 import { isAdmin } from 'data/user'
 import { formatFriendlyDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
@@ -43,7 +43,7 @@ onMount(() => {
   loadClaimsByPolicyId(policyId)
 })
 $: policy = $selectedPolicy
-$: $selectedPolicy.id !== policyId && loadPolicy($selectedPolicy.id)
+$: $selectedPolicyId !== policyId && loadPolicy($selectedPolicyId)
 
 $: members = policy.members || []
 

--- a/src/pages/policies/[policyId]/items/[itemId]/checkout.svelte
+++ b/src/pages/policies/[policyId]/items/[itemId]/checkout.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-import Checkout from 'Checkout.svelte'
+import { Checkout } from 'components'
 import { deleteItem, loadItems, PolicyItem, selectedPolicyItems, submitItem } from 'data/items'
-import { selectedPolicyId } from 'data/role-policy-selection'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { itemDetails, items, itemEdit } from 'helpers/routes'
-import { goto, metatags } from '@roxi/routify'
+import { goto, metatags, params } from '@roxi/routify'
 import { Page } from '@silintl/ui-components'
 import { onMount } from 'svelte'
 
@@ -14,7 +13,7 @@ onMount(() => {
   loadItems(policyId)
 })
 
-$: policyId = $selectedPolicyId
+$: policyId = $params.policyId
 $: item = $selectedPolicyItems.find((i) => i.id === itemId) as PolicyItem
 $: metatags.title = formatPageTitle('Items > Checkout')
 

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Breadcrumb, ItemForm, NoHouseholdIdModal } from 'components'
 import { loadDependents } from 'data/dependents'
-import { addItem, itemsByPolicyId, loadItems, PolicyItem, updateItem } from 'data/items'
+import { addItem, loadItems, PolicyItem, selectedPolicyItems, updateItem } from 'data/items'
 import { PolicyType, selectedPolicy, updatePolicy } from 'data/policies'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -19,16 +19,15 @@ let open = false
 onMount(() => {
   loadDependents(policyId)
   loadMembersOfPolicy(policyId)
+  loadItems(policyId)
 })
 
 $: metatags.title = formatPageTitle('Items > New')
 
-$: policyId && loadItems(policyId)
-
 $: item.id && $redirect(itemsNewId(policyId, qs.stringify({ itemId: item.id })))
 $: $selectedPolicy.type === PolicyType.Household && !$selectedPolicy.household_id && (open = true)
 
-$: $params.itemId && (item = $itemsByPolicyId[policyId]?.find((i) => i.id === $params.itemId) || {})
+$: $params.itemId && (item = $selectedPolicyItems.find((i) => i.id === $params.itemId) || {})
 $: breadcrumbLinks = [
   { name: 'Items', url: itemsRoute(policyId) },
   { name: 'New', url: item.id ? itemsNewId(policyId, qs.stringify({ itemId: item.id })) : itemsNew(policyId) },

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -3,11 +3,10 @@ import { Breadcrumb, ItemForm, NoHouseholdIdModal } from 'components'
 import { loadDependents } from 'data/dependents'
 import {
   addItem,
-  ItemFormData,
   loadItems,
   NewItemFormData,
   PolicyItem,
-  SaveFormData,
+  UpdateItemFormData,
   selectedPolicyItems,
   updateItem,
 } from 'data/items'
@@ -48,7 +47,7 @@ const onApply = async (event: CustomEvent) => {
 }
 
 const onSaveForLater = async (event: CustomEvent) => {
-  const itemData: SaveFormData = event.detail
+  const itemData: UpdateItemFormData = event.detail
   saveOrAddItem(itemData)
 
   if (!event.detail.isAutoSaving) {
@@ -56,7 +55,7 @@ const onSaveForLater = async (event: CustomEvent) => {
   }
 }
 
-const saveOrAddItem = async (itemData: ItemFormData | NewItemFormData) =>
+const saveOrAddItem = async (itemData: UpdateItemFormData | NewItemFormData) =>
   item.id
     ? await updateItem(policyId, item.id, itemData)
     : (item = await addItem(policyId, itemData as NewItemFormData))

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -31,13 +31,13 @@ onMount(() => {
 
 $: metatags.title = formatPageTitle('Items > New')
 
-$: item.id && $redirect(itemsNewQs(policyId, { itemId: item.id }))
+$: item.id && $redirect(itemsNewQs(policyId, item.id))
 $: $selectedPolicy.type === PolicyType.Household && !$selectedPolicy.household_id && (open = true)
 
 $: $params.itemId && (item = $selectedPolicyItems.find((i) => i.id === $params.itemId) || {})
 $: breadcrumbLinks = [
   { name: 'Items', url: itemsRoute(policyId) },
-  { name: 'New', url: item.id ? itemsNewQs(policyId, { itemId: item.id }) : itemsNew(policyId) },
+  { name: 'New', url: item.id ? itemsNewQs(policyId, item.id) : itemsNew(policyId) },
 ]
 
 const onApply = async (event: CustomEvent) => {

--- a/src/pages/policies/[policyId]/items/new.svelte
+++ b/src/pages/policies/[policyId]/items/new.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
 import { Breadcrumb, ItemForm, NoHouseholdIdModal } from 'components'
 import { loadDependents } from 'data/dependents'
-import { addItem, loadItems, PolicyItem, selectedPolicyItems, updateItem } from 'data/items'
+import {
+  addItem,
+  ItemFormData,
+  loadItems,
+  NewItemFormData,
+  PolicyItem,
+  SaveFormData,
+  selectedPolicyItems,
+  updateItem,
+} from 'data/items'
 import { PolicyType, selectedPolicy, updatePolicy } from 'data/policies'
 import { loadMembersOfPolicy } from 'data/policy-members'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { HOME, items as itemsRoute, itemsCheckout, itemsNew, itemsNewId } from 'helpers/routes'
-import qs from 'qs'
+import { HOME, items as itemsRoute, itemsCheckout, itemsNew, itemsNewQs } from 'helpers/routes'
 import { goto, metatags, params, redirect } from '@roxi/routify'
 import { Page, setNotice } from '@silintl/ui-components'
 import { onMount } from 'svelte'
@@ -24,30 +32,34 @@ onMount(() => {
 
 $: metatags.title = formatPageTitle('Items > New')
 
-$: item.id && $redirect(itemsNewId(policyId, qs.stringify({ itemId: item.id })))
+$: item.id && $redirect(itemsNewQs(policyId, { itemId: item.id }))
 $: $selectedPolicy.type === PolicyType.Household && !$selectedPolicy.household_id && (open = true)
 
 $: $params.itemId && (item = $selectedPolicyItems.find((i) => i.id === $params.itemId) || {})
 $: breadcrumbLinks = [
   { name: 'Items', url: itemsRoute(policyId) },
-  { name: 'New', url: item.id ? itemsNewId(policyId, qs.stringify({ itemId: item.id })) : itemsNew(policyId) },
+  { name: 'New', url: item.id ? itemsNewQs(policyId, { itemId: item.id }) : itemsNew(policyId) },
 ]
 
 const onApply = async (event: CustomEvent) => {
-  await saveOrAddItem(event)
+  const itemData: NewItemFormData = event.detail
+  await saveOrAddItem(itemData)
   $goto(itemsCheckout(policyId, item.id))
 }
 
 const onSaveForLater = async (event: CustomEvent) => {
-  saveOrAddItem(event)
+  const itemData: SaveFormData = event.detail
+  saveOrAddItem(itemData)
 
   if (!event.detail.isAutoSaving) {
     $goto(HOME)
   }
 }
 
-const saveOrAddItem = async (event: CustomEvent) =>
-  item.id ? await updateItem(policyId, item.id, event.detail) : (item = await addItem(policyId, event.detail))
+const saveOrAddItem = async (itemData: ItemFormData | NewItemFormData) =>
+  item.id
+    ? await updateItem(policyId, item.id, itemData)
+    : (item = await addItem(policyId, itemData as NewItemFormData))
 
 const onClosed = async (event: CustomEvent<any>) => {
   const choice = event.detail.choice


### PR DESCRIPTION
- added a qs for ItemId in ItemsNew
- fixed a bug (on my machine anyways) where Checkout wasn't importing properly
- fixed a bug where policyId was undefined

To summarize now can can go to ItemsNew, fill it out (minimum of name and category for it to create an item), navigate to Checkout or anywhere else, click 🔙   and arrive back at `ItemsNew` with the data still intact.