### PR TITLE
add NewCoverageModal to claim view

### DIFF
--- a/src/components/NewCoverageModal.svelte
+++ b/src/components/NewCoverageModal.svelte
@@ -3,6 +3,7 @@ import { Dialog } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
 export let open = true
+export let itemName = ''
 
 let title = 'Replacement coverage'
 
@@ -19,5 +20,5 @@ const handleDialog = (e: CustomEvent) => {
 </script>
 
 <Dialog.Alert {open} {buttons} defaultAction="cancel" {title} on:chosen={handleDialog} on:closed={handleDialog}>
-  We’re ending coverage for Saxophone since you’ve replaced it. Would you like to cover its replacement?
+  We’re ending coverage for {itemName} since you’ve replaced it. Would you like to cover its replacement?
 </Dialog.Alert>

--- a/src/components/NewCoverageModal.svelte
+++ b/src/components/NewCoverageModal.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { Dialog } from '@silintl/ui-components'
+import { createEventDispatcher } from 'svelte'
+
+export let open = true
+
+let title = 'Replacement coverage'
+
+const buttons: Dialog.AlertButton[] = [
+  { label: 'not now', action: 'cancel', class: 'mdc-button--raised' },
+  { label: 'Add Coverage for Replacement', action: 'reCover', class: 'mdc-dialog__button' },
+]
+
+const dispatch = createEventDispatcher<{ closed: string }>()
+
+const handleDialog = (e: CustomEvent) => {
+  e.detail ? dispatch(e.detail) : dispatch('closed')
+}
+</script>
+
+<Dialog.Alert {open} {buttons} defaultAction="cancel" {title} on:chosen={handleDialog} on:closed={handleDialog}>
+  We’re ending coverage for Saxophone since you’ve replaced it. Would you like to cover its replacement?
+</Dialog.Alert>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,6 +25,7 @@ import ItemDeleteModal from './ItemDeleteModal.svelte'
 import ItemDetails from './ItemDetails.svelte'
 import ItemForm from './forms/ItemForm.svelte'
 import NoHouseholdIdModal from './NoHouseholdIdModal.svelte'
+import NewCoverageModal from './NewCoverageModal.svelte'
 import Paginator from './Paginator.svelte'
 import RadioOptions from './RadioOptions.svelte'
 import RecentActivityTable from './RecentActivityTable.svelte'
@@ -64,6 +65,7 @@ export {
   ItemForm,
   ItemsTable,
   NoHouseholdIdModal,
+  NewCoverageModal,
   Paginator,
   RadioOptions,
   CardsGrid,

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -301,3 +301,20 @@ export const itemIsApproved = (item: PolicyItem): boolean => {
 export const itemIsInactive = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Inactive
 }
+
+export const parseItemForAddItem = (item: PolicyItem): any => {
+  return {
+    accountablePersonId: item.accountable_person.id,
+    categoryId: item.category.id,
+    country: item.country || item.accountable_person.country,
+    marketValueUSD: item.coverage_amount / 100,
+    coverageStartDate: new Date().toISOString().slice(0, 10),
+    description: item.description,
+    inStorage: item.in_storage,
+    make: item.make,
+    model: item.model,
+    name: item.name,
+    riskCategoryId: item.risk_category.id,
+    uniqueIdentifier: item.serial_number,
+  }
+}

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -49,7 +49,6 @@ import {
   customerClaimDetails,
   POLICIES,
   policyDetails,
-  itemsNew,
   itemEdit,
 } from 'helpers/routes'
 import { formatPageTitle } from 'helpers/pageTitle'

--- a/src/pages/policies/[policyId]/claims/[claimId].svelte
+++ b/src/pages/policies/[policyId]/claims/[claimId].svelte
@@ -408,6 +408,7 @@ const onReCover = async () => {
 
   <RevokeModal {claim} open={revokeModalOpen} on:closed={onRevoke} />
   <NewCoverageModal
+    itemName={item.name}
     open={newCoverageModalOpen}
     on:reCover={onReCover}
     on:cancel={() => (newCoverageModalOpen = false)}


### PR DESCRIPTION
- Add modal to offer new coverage for replaced items after uploading replace receipt
- create a new item with the old item's data
- send the user to itemEdit to edit the new item