### PR TITLE
Disable Batch Delete when ended items selected and assert no open claims

### DIFF
--- a/src/components/BatchItemClone.svelte
+++ b/src/components/BatchItemClone.svelte
@@ -30,7 +30,7 @@ const handleDialog = (choice: 'clone' | 'cancel') => {
 }
 </script>
 
-<Button {disabled} on:click={() => (open = true)}>clone coverage</Button>
+<Button class="mb-1" {disabled} on:click={() => (open = true)}>clone coverage</Button>
 
 <Dialog.Alert
   {open}

--- a/src/components/BatchItemDelete.svelte
+++ b/src/components/BatchItemDelete.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Button, Dialog } from '@silintl/ui-components'
+import { Button, Dialog, IconButton } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
 
 export let openModal = false
@@ -12,16 +12,20 @@ const buttons: Dialog.AlertButton[] = [
   { label: 'yes, delete', action: 'delete', class: 'error-button' },
   { label: 'cancel', action: 'cancel', class: 'mdc-dialog__button' },
 ]
+let infoModalOpen = false
 
 $: buttonLabel = allCheckedItemsAreDraft ? 'delete' : 'end coverage'
 
 const handleDialog = (choice: string) => {
   openModal = false
+  infoModalOpen = false
   dispatch('closed', choice)
 }
 </script>
 
-<Button {disabled} on:click={() => (openModal = true)}>{buttonLabel}</Button>
+<Button class="mb-1" {disabled} on:click={() => (openModal = true)}>{buttonLabel}</Button>
+
+<IconButton class="gray" icon="info" on:click={() => (infoModalOpen = true)} />
 
 <Dialog.Alert
   open={openModal}
@@ -31,4 +35,14 @@ const handleDialog = (choice: string) => {
   on:chosen={(e) => handleDialog(e.detail)}
   on:closed={handleDialog}
   >Are you sure you would like to remove coverage or delete the selected items (coverage ends at a later date)?</Dialog.Alert
+>
+
+<Dialog.Alert
+  open={infoModalOpen}
+  buttons={[{ label: 'ok', action: 'cancel', class: 'mdc-dialog__button' }]}
+  defaultAction="cancel"
+  title={"Some items can't be deleted"}
+  on:chosen={(e) => handleDialog(e.detail)}
+  on:closed={handleDialog}
+  >Items with no coverage, a scheduled end date, or an open claim can't be deleted.</Dialog.Alert
 >

--- a/src/components/Datatable/ItemsTable.svelte
+++ b/src/components/Datatable/ItemsTable.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 import BatchItemClone from '../BatchItemClone.svelte'
 import BatchItemDelete from '../BatchItemDelete.svelte'
+import { ClaimItem, incompleteClaimItemStatuses, selectedPolicyClaims } from 'data/claims'
 import { getItemState } from 'data/states'
 import { AccountablePerson, editableCoverageStatuses, ItemCoverageStatus, PolicyItem } from 'data/items'
 import { formatDate, formatFriendlyDate } from 'helpers/dates'
+import { throwError } from '../../error'
 import { formatMoney } from 'helpers/money'
 import { itemDetails, itemEdit } from 'helpers/routes'
 import { sortByNum, sortByString } from 'helpers/sort'
@@ -11,6 +13,7 @@ import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import type { Column } from './types'
 import { createEventDispatcher } from 'svelte'
 import { Datatable, Menu, MenuItem } from '@silintl/ui-components'
+import { capitalize } from 'lodash-es'
 
 export let items = [] as PolicyItem[]
 export let policyId: string
@@ -81,6 +84,10 @@ $: sortedItemsArray = currentColumn.numeric
 $: allCheckedItemsAreDraft =
   checkedItems.length > 0 && checkedItems.every((item) => item.coverage_status === ItemCoverageStatus.Draft)
 $: batchActionDisabled = checkedItems.length === 0
+$: batchDeleteDisabled =
+  batchActionDisabled ||
+  checkedItems.some((item) => item.coverage_end_date || item.coverage_status === ItemCoverageStatus.Inactive)
+$: items && uncheckItemsNotShown()
 
 const dispatch = createEventDispatcher()
 
@@ -120,6 +127,7 @@ const handleModalDialog = async (event: CustomEvent<string>) => {
 
 const handleClosed = (e: CustomEvent<string>) => {
   if (e.detail === 'delete') {
+    assertItemsHaveNoOpenClaims(checkedItems)
     dispatch('batchDelete', checkedItems)
   }
   if (e.detail === 'clone') {
@@ -182,6 +190,24 @@ const onRowSelectionChanged = (event: CustomEvent) => {
 const registerNewCheckbox = () => {
   numberOfCheckboxes++
 }
+
+const uncheckItemsNotShown = () => {
+  checkedItems = checkedItems.filter((item) => items.includes(item))
+}
+
+const assertItemsHaveNoOpenClaims = (items: PolicyItem[]): void => {
+  const checkClaimItemsForItemAndOpenClaim = (claimItems: ClaimItem[], item: PolicyItem) => {
+    const hasOpenClaim = claimItems.some(
+      (claimItem) => claimItem.item_id === item.id && incompleteClaimItemStatuses.includes(claimItem.status)
+    )
+    if (hasOpenClaim) {
+      throwError(`${capitalize(item.name)} has an open claim, you cannot end coverage until it is resolved.`)
+    }
+  }
+  $selectedPolicyClaims.forEach((claim) => {
+    items.forEach((item) => checkClaimItemsForItemAndOpenClaim(claim.claim_items, item))
+  })
+}
 </script>
 
 <style>
@@ -205,7 +231,7 @@ const registerNewCheckbox = () => {
 }
 </style>
 
-<BatchItemDelete disabled={batchActionDisabled} {allCheckedItemsAreDraft} on:closed={handleClosed} />
+<BatchItemDelete disabled={batchDeleteDisabled} {allCheckedItemsAreDraft} on:closed={handleClosed} />
 
 <BatchItemClone disabled={batchActionDisabled} {selectedItemNames} on:closed={handleClosed} />
 

--- a/src/components/Datatable/ItemsTable.svelte
+++ b/src/components/Datatable/ItemsTable.svelte
@@ -87,7 +87,7 @@ $: batchActionDisabled = checkedItems.length === 0
 $: batchDeleteDisabled =
   batchActionDisabled ||
   checkedItems.some((item) => item.coverage_end_date || item.coverage_status === ItemCoverageStatus.Inactive)
-$: items && uncheckItemsNotShown()
+$: items && (checkedItems = returnFilteredCheckedItems())
 
 const dispatch = createEventDispatcher()
 
@@ -191,9 +191,7 @@ const registerNewCheckbox = () => {
   numberOfCheckboxes++
 }
 
-const uncheckItemsNotShown = () => {
-  checkedItems = checkedItems.filter((item) => items.includes(item))
-}
+const returnFilteredCheckedItems = () => checkedItems.filter((ci) => items.some((i) => i.id === ci.id))
 
 const assertItemsHaveNoOpenClaims = (items: PolicyItem[]): void => {
   const checkClaimItemsForItemAndOpenClaim = (claimItems: ClaimItem[], item: PolicyItem) => {

--- a/src/components/Datatable/ItemsTable.svelte
+++ b/src/components/Datatable/ItemsTable.svelte
@@ -227,6 +227,10 @@ const assertItemsHaveNoOpenClaims = (items: PolicyItem[]): void => {
   position: absolute;
   right: 235px;
 }
+
+.red {
+  color: var(--mdc-theme-status-error);
+}
 </style>
 
 <BatchItemDelete disabled={batchDeleteDisabled} {allCheckedItemsAreDraft} on:closed={handleClosed} />
@@ -259,7 +263,7 @@ const assertItemsHaveNoOpenClaims = (items: PolicyItem[]): void => {
         <Datatable.Data.Row.Item>{item.name || ''}</Datatable.Data.Row.Item>
         <Datatable.Data.Row.Item class={getStatusClass(item.coverage_status)}>
           {#if item.coverage_status === ItemCoverageStatus.Approved && item.coverage_end_date}
-            Covered through {formatFriendlyDate(item.coverage_end_date)}
+            <div class="red">Covered through {formatFriendlyDate(item.coverage_end_date)}</div>
           {:else}
             {getItemState(item.coverage_status)?.title || ''}
           {/if}


### PR DESCRIPTION
- Disable Batch Delete when ended items selected
- Assert no open claims on items being deleted
- make item.status column red in ItemsTable to draw attention that coverage cancellation has already happened
  
![image](https://user-images.githubusercontent.com/70765247/178683701-e900b10a-91b8-4a88-8350-e0f349e0714d.png)
