### PR TITLE
add save, save changes and discard button to personal settings

### DIFF
--- a/src/pages/settings/personal.svelte
+++ b/src/pages/settings/personal.svelte
@@ -27,10 +27,28 @@ metatags.title = formatPageTitle('Personal Settings')
 
 $: country = $user.country || ''
 $: $user.id && setEmail()
+$: customEmailHasChanged = email_override && email_override !== $user.email_override
 $: notificationOptions = [
   { label: 'Default email: ' + $user.email, value: NOTIFICATION_OPTION_DEFAULT },
   { label: 'Custom email', value: NOTIFICATION_OPTION_CUSTOM },
 ]
+
+function onSave() {
+  if (customEmailHasChanged) {
+    updateCustomEmail()
+  } else {
+    setNotice('Changes are saved after each change')
+  }
+}
+
+function onDiscard() {
+  if (customEmailHasChanged) {
+    email_override = $user.email_override
+    setNotice('Your changes have been discarded')
+  } else {
+    setNotice('No changes to discard')
+  }
+}
 
 const setEmail = () => {
   if ($user.email_override !== $user.email) {
@@ -158,7 +176,10 @@ p {
     />
   </p>
   {#if notification_email === NOTIFICATION_OPTION_CUSTOM}
-    <TextField {maxlength} label="Custom email" bind:value={email_override} on:blur={updateCustomEmail} />
+    <TextField {maxlength} label="Custom email" bind:value={email_override} />
+    {#if customEmailHasChanged}
+      <Button raised on:click={updateCustomEmail}>save</Button>
+    {/if}
   {/if}
 
   <p>
@@ -185,8 +206,11 @@ p {
   {/if}
 
   {#if !croppieIsHidden}
-    <Button raised on:click={onUpload}>Save</Button>
+    <Button raised on:click={onUpload}>save</Button>
   {/if}
 
   <RemoveProfilePicModal {open} on:closed={onDelete} />
+
+  <Button raised on:click={onSave}>save changes</Button>
+  <Button on:click={onDiscard}>discard changes</Button>
 </Page>

--- a/src/pages/settings/personal.svelte
+++ b/src/pages/settings/personal.svelte
@@ -27,27 +27,13 @@ metatags.title = formatPageTitle('Personal Settings')
 
 $: country = $user.country || ''
 $: $user.id && setEmail()
-$: customEmailHasChanged = email_override && email_override !== $user.email_override
 $: notificationOptions = [
   { label: 'Default email: ' + $user.email, value: NOTIFICATION_OPTION_DEFAULT },
   { label: 'Custom email', value: NOTIFICATION_OPTION_CUSTOM },
 ]
 
 function onSave() {
-  if (customEmailHasChanged) {
-    updateCustomEmail()
-  } else {
-    setNotice('Changes are saved after each change')
-  }
-}
-
-function onDiscard() {
-  if (customEmailHasChanged) {
-    email_override = $user.email_override
-    setNotice('Your changes have been discarded')
-  } else {
-    setNotice('No changes to discard')
-  }
+  setNotice('Changes are saved after each change')
 }
 
 const setEmail = () => {
@@ -176,10 +162,7 @@ p {
     />
   </p>
   {#if notification_email === NOTIFICATION_OPTION_CUSTOM}
-    <TextField {maxlength} label="Custom email" bind:value={email_override} />
-    {#if customEmailHasChanged}
-      <Button raised on:click={updateCustomEmail}>save</Button>
-    {/if}
+    <TextField {maxlength} label="Custom email" bind:value={email_override} on:blur={updateCustomEmail} />
   {/if}
 
   <p>
@@ -212,5 +195,4 @@ p {
   <RemoveProfilePicModal {open} on:closed={onDelete} />
 
   <Button raised on:click={onSave}>save changes</Button>
-  <Button on:click={onDiscard}>discard changes</Button>
 </Page>


### PR DESCRIPTION
- Added buttons to personal settings
- custom_email gets saved when either "save" or "save changes" is clicked rather than on:blur
see https://trello.com/c/znDg06sW/245-add-save-changes-button-to-the-bottom-of-settings-pages-tell-user-about-autosave-onclick

![image](https://user-images.githubusercontent.com/70765247/220223161-f18f931b-0746-4a7f-a909-13a8356a4837.png)
