### PR TITLE
Sort recent changes

### DIFF
--- a/src/components/RadioOptions.svelte
+++ b/src/components/RadioOptions.svelte
@@ -22,7 +22,7 @@ const optionId = (option: RadioOption) => `radio-options-${String(option.value).
   display: block;
 }
 input {
-  margin-right: 0.3rem;
+  margin-right: 0.6rem;
   margin-bottom: 0.2rem;
 }
 </style>

--- a/src/components/RadioOptions.svelte
+++ b/src/components/RadioOptions.svelte
@@ -22,7 +22,7 @@ const optionId = (option: RadioOption) => `radio-options-${String(option.value).
   display: block;
 }
 input {
-  margin-right: 0.6rem;
+  margin-right: 0.3rem;
   margin-bottom: 0.2rem;
 }
 </style>


### PR DESCRIPTION
- refactored so Claims are guaranteed at the beginning of the array in recent changes on admin/home
- For Signators Claims willl only be of status `Review3` so they will be first. Stewards don't see these
see https://trello.com/c/4dKEP19z/399-for-stewards-reorder-action-cards-on-home

![image](https://user-images.githubusercontent.com/70765247/221102272-fcdba032-3191-4d4b-ac15-84bb1b2514db.png)
