### PR TITLE
audit renewals and repairs

### DIFF
--- a/src/components/progress/index.ts
+++ b/src/components/progress/index.ts
@@ -21,3 +21,7 @@ export const stop = (id: string): void => {
 
 export const isLoadingById = (id: string): boolean => pending.includes(id)
 export const isLoadingPolicyItems = (policyId: string): boolean => pending.includes(`policies/${policyId}/items`)
+export async function delayLoading(loading: boolean, ms = 500): Promise<boolean> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+  return loading
+}

--- a/src/data/audits.ts
+++ b/src/data/audits.ts
@@ -24,5 +24,4 @@ export const repairAudits = async (date: string): Promise<void> => {
   const response = (await CREATE('repairs', { repair_type: 'renewal', date })) as RepairsResult
 
   repairedAudits.set(response)
-  audits.set({} as AuditResult)
 }

--- a/src/data/audits.ts
+++ b/src/data/audits.ts
@@ -8,8 +8,16 @@ export type AuditResult = {
 }
 
 export const audits = writable({} as AuditResult)
+export const repairedAudits = writable({} as AuditResult)
 
 export const runAudits = async (date: string): Promise<void> => {
   const response = (await CREATE('audits', { audit_type: 'renewal', Date: date })) as AuditResult
   audits.set(response)
+}
+
+export const repairAudits = async (date: string): Promise<void> => {
+  const response = (await CREATE('audits', { audit_type: 'repair', Date: date })) as AuditResult
+
+  repairedAudits.set(response)
+  audits.set({} as AuditResult)
 }

--- a/src/data/audits.ts
+++ b/src/data/audits.ts
@@ -11,12 +11,12 @@ export const audits = writable({} as AuditResult)
 export const repairedAudits = writable({} as AuditResult)
 
 export const runAudits = async (date: string): Promise<void> => {
-  const response = (await CREATE('audits', { audit_type: 'renewal', Date: date })) as AuditResult
+  const response = (await CREATE('audits', { audit_type: 'renewal', date })) as AuditResult
   audits.set(response)
 }
 
 export const repairAudits = async (date: string): Promise<void> => {
-  const response = (await CREATE('audits', { audit_type: 'repair', Date: date })) as AuditResult
+  const response = (await CREATE('repairs', { repair_type: 'renewal', date })) as AuditResult
 
   repairedAudits.set(response)
   audits.set({} as AuditResult)

--- a/src/data/audits.ts
+++ b/src/data/audits.ts
@@ -1,12 +1,15 @@
 import type { PolicyItem } from './items'
 import { CREATE } from 'data'
+import { writable } from 'svelte/store'
 
 export type AuditResult = {
   AuditType: string
   Items: PolicyItem[]
 }
 
-export const runAudits = async (date: string): Promise<AuditResult> => {
+export const audits = writable({} as AuditResult)
+
+export const runAudits = async (date: string): Promise<void> => {
   const response = (await CREATE('audits', { audit_type: 'renewal', Date: date })) as AuditResult
-  return response
+  audits.set(response)
 }

--- a/src/data/audits.ts
+++ b/src/data/audits.ts
@@ -3,12 +3,17 @@ import { CREATE } from 'data'
 import { writable } from 'svelte/store'
 
 export type AuditResult = {
-  AuditType: string
-  Items: PolicyItem[]
+  audit_type: string
+  items: PolicyItem[]
+}
+
+export type RepairsResult = {
+  repair_type: string
+  items: PolicyItem[]
 }
 
 export const audits = writable({} as AuditResult)
-export const repairedAudits = writable({} as AuditResult)
+export const repairedAudits = writable({} as RepairsResult)
 
 export const runAudits = async (date: string): Promise<void> => {
   const response = (await CREATE('audits', { audit_type: 'renewal', date })) as AuditResult
@@ -16,7 +21,7 @@ export const runAudits = async (date: string): Promise<void> => {
 }
 
 export const repairAudits = async (date: string): Promise<void> => {
-  const response = (await CREATE('repairs', { repair_type: 'renewal', date })) as AuditResult
+  const response = (await CREATE('repairs', { repair_type: 'renewal', date })) as RepairsResult
 
   repairedAudits.set(response)
   audits.set({} as AuditResult)

--- a/src/data/audits.ts
+++ b/src/data/audits.ts
@@ -1,0 +1,12 @@
+import type { PolicyItem } from './items'
+import { CREATE } from 'data'
+
+export type AuditResult = {
+  AuditType: string
+  Items: PolicyItem[]
+}
+
+export const runAudits = async (date: string): Promise<AuditResult> => {
+  const response = (await CREATE('audits', { audit_type: 'renewal', Date: date })) as AuditResult
+  return response
+}

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -446,3 +446,7 @@ export const getClaimById = async (claimId: string): Promise<Claim> => {
 export const claimIsOpen = (claim: Claim): boolean => {
   return incompleteClaimItemStatuses.includes(claim.status)
 }
+
+export const claimIsOpenButNotDraft = (claim: Claim): boolean => {
+  return claimIsOpen(claim) && claim.status !== ClaimStatus.Draft
+}

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -446,7 +446,3 @@ export const getClaimById = async (claimId: string): Promise<Claim> => {
 export const claimIsOpen = (claim: Claim): boolean => {
   return incompleteClaimItemStatuses.includes(claim.status)
 }
-
-export const claimIsOpenButNotDraft = (claim: Claim): boolean => {
-  return claimIsOpen(claim) && claim.status !== ClaimStatus.Draft
-}

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,5 +1,5 @@
 import { CREATE, DELETE, GET, UPDATE } from '.'
-import { claimIsOpen, claims, loadClaimsByPolicyId } from 'data/claims'
+import { claimIsOpenButNotDraft, claims, loadClaimsByPolicyId } from 'data/claims'
 import { throwError } from '../error'
 import { derived, get, writable } from 'svelte/store'
 import { selectedPolicyId } from './role-policy-selection'
@@ -380,7 +380,7 @@ export const isItemWithActiveClaim = async (itemId: string, policyId: string): P
   let hasActiveClaim = false
 
   get(claims).forEach((claim) => {
-    if (claimIsOpen(claim)) {
+    if (claimIsOpenButNotDraft(claim)) {
       hasActiveClaim = claim.claim_items.some((item) => item.item_id === itemId)
       if (hasActiveClaim) return
     }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,5 +1,4 @@
 import { CREATE, DELETE, GET, UPDATE } from '.'
-import { claimIsOpenButNotDraft, claims, loadClaimsByPolicyId } from 'data/claims'
 import { throwError } from '../error'
 import { derived, get, writable } from 'svelte/store'
 import { selectedPolicyId } from './role-policy-selection'
@@ -57,6 +56,8 @@ export type PolicyItem = {
   description: string
   id: string
   in_storage: boolean
+  can_be_deleted: boolean
+  can_be_updated: boolean
   make: string
   model: string
   name: string
@@ -373,17 +374,4 @@ export const parseItemForAddItem = (item: PolicyItem): NewItemFormData => {
     riskCategoryId: item.risk_category.id,
     uniqueIdentifier: item.serial_number,
   }
-}
-
-export const isItemWithActiveClaim = async (itemId: string, policyId: string): Promise<boolean> => {
-  await loadClaimsByPolicyId(policyId)
-  let hasActiveClaim = false
-
-  get(claims).forEach((claim) => {
-    if (claimIsOpenButNotDraft(claim)) {
-      hasActiveClaim = claim.claim_items.some((item) => item.item_id === itemId)
-      if (hasActiveClaim) return
-    }
-  })
-  return hasActiveClaim
 }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,4 +1,5 @@
 import { CREATE, DELETE, GET, UPDATE } from '.'
+import { claimIsOpen, claims, loadClaimsByPolicyId } from 'data/claims'
 import { throwError } from '../error'
 import { derived, get, writable } from 'svelte/store'
 import { selectedPolicyId } from './role-policy-selection'
@@ -372,4 +373,17 @@ export const parseItemForAddItem = (item: PolicyItem): NewItemFormData => {
     riskCategoryId: item.risk_category.id,
     uniqueIdentifier: item.serial_number,
   }
+}
+
+export const isItemWithActiveClaim = async (itemId: string, policyId: string): Promise<boolean> => {
+  await loadClaimsByPolicyId(policyId)
+  let hasActiveClaim = false
+
+  get(claims).forEach((claim) => {
+    if (claimIsOpen(claim)) {
+      hasActiveClaim = claim.claim_items.some((item) => item.item_id === itemId)
+      if (hasActiveClaim) return
+    }
+  })
+  return hasActiveClaim
 }

--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -13,6 +13,8 @@ export const adminPolicySearch = (query: string) => `/admin/policies?${query}`
 export const ENTITIES = '/admin/entities'
 export const entityDetails = (entityId: string) => `/admin/entities/${entityId}`
 
+export const AUDITS = '/admin/audits'
+
 export const CHAT = '/chat'
 
 export const CLAIMS = '/claims'

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -51,6 +51,13 @@ $: menuItems = [
     hide: userNotAdmin,
   },
   {
+    url: routes.AUDITS,
+    icon: 'history',
+    label: 'Audits',
+    hide: userNotAdmin,
+  },
+  // Non admin menu items
+  {
     url: routes.policyDetails(policyId),
     icon: 'description',
     label: 'Policy',

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -52,7 +52,7 @@ $: menuItems = [
   },
   {
     url: routes.AUDITS,
-    icon: 'history',
+    icon: 'sync_problem',
     label: 'Audits',
     hide: userNotAdmin,
   },

--- a/src/pages/admin/_components/AuditsOrRepairTable.svelte
+++ b/src/pages/admin/_components/AuditsOrRepairTable.svelte
@@ -24,21 +24,25 @@ const preventRowClick = async () => {
 }
 </script>
 
+<style>
+:global(.audit-header:hover) {
+  cursor: default;
+}
+</style>
+
 {#if items.length}
   <Datatable>
     <Datatable.Header>
-      <Datatable.Header.Item>Name</Datatable.Header.Item>
-      <Datatable.Header.Item>Policy</Datatable.Header.Item>
-      <Datatable.Header.Item>Annual Premium</Datatable.Header.Item>
-      <Datatable.Header.Item>End Date</Datatable.Header.Item>
-      <Datatable.Header.Item>Coverage Status</Datatable.Header.Item>
-      <Datatable.Header.Item>Action</Datatable.Header.Item>
+      <Datatable.Header.Item class="audit-header">Name</Datatable.Header.Item>
+      <Datatable.Header.Item class="audit-header">Annual Premium</Datatable.Header.Item>
+      <Datatable.Header.Item class="audit-header">End Date</Datatable.Header.Item>
+      <Datatable.Header.Item class="audit-header">Coverage Status</Datatable.Header.Item>
+      <Datatable.Header.Item class="audit-header">Action</Datatable.Header.Item>
     </Datatable.Header>
     <Datatable.Data>
       {#each items as item (item.id)}
         <Datatable.Data.Row on:click={() => gotoItemDetails(item)} clickable>
           <Datatable.Data.Row.Item>{item.name}</Datatable.Data.Row.Item>
-          <Datatable.Data.Row.Item>{item.policy_id}</Datatable.Data.Row.Item>
           <Datatable.Data.Row.Item>{formatMoney(item.annual_premium)}</Datatable.Data.Row.Item>
           <Datatable.Data.Row.Item>{formatDate(item.coverage_end_date)}</Datatable.Data.Row.Item>
           <Datatable.Data.Row.Item>{item.coverage_status}</Datatable.Data.Row.Item>

--- a/src/pages/admin/_components/AuditsOrRepairTable.svelte
+++ b/src/pages/admin/_components/AuditsOrRepairTable.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { delayLoading, loading } from 'components/progress'
 import type { PolicyItem } from 'data/items'
+import { formatDate } from 'helpers/dates'
+import { formatMoney } from 'helpers/money'
 import { itemDetails, policyDetails } from 'helpers/routes'
 import { goto } from '@roxi/routify'
 import { Button, Datatable } from '@silintl/ui-components'
@@ -37,8 +39,8 @@ const preventRowClick = async () => {
         <Datatable.Data.Row on:click={() => gotoItemDetails(item)} clickable>
           <Datatable.Data.Row.Item>{item.name}</Datatable.Data.Row.Item>
           <Datatable.Data.Row.Item>{item.policy_id}</Datatable.Data.Row.Item>
-          <Datatable.Data.Row.Item>{item.annual_premium}</Datatable.Data.Row.Item>
-          <Datatable.Data.Row.Item>{item.coverage_end_date}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{formatMoney(item.annual_premium)}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{formatDate(item.coverage_end_date)}</Datatable.Data.Row.Item>
           <Datatable.Data.Row.Item>{item.coverage_status}</Datatable.Data.Row.Item>
           <Datatable.Data.Row.Item>
             <Button url={policyDetails(item.policy_id)} on:click={preventRowClick}>view policy</Button>

--- a/src/pages/admin/_components/AuditsOrRepairTable.svelte
+++ b/src/pages/admin/_components/AuditsOrRepairTable.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import { delayLoading, loading } from 'components/progress'
+import type { PolicyItem } from 'data/items'
+import { itemDetails, policyDetails } from 'helpers/routes'
+import { goto } from '@roxi/routify'
+import { Button, Datatable } from '@silintl/ui-components'
+
+export let items: PolicyItem[] = []
+
+let canViewItemDetails = true
+
+const gotoItemDetails = (item: PolicyItem) => {
+  if (canViewItemDetails) {
+    $goto(itemDetails(item.policy_id, item.id))
+  } else {
+    canViewItemDetails = true
+  }
+}
+
+const preventRowClick = async () => {
+  canViewItemDetails = false
+}
+</script>
+
+{#if items.length}
+  <Datatable>
+    <Datatable.Header>
+      <Datatable.Header.Item>Name</Datatable.Header.Item>
+      <Datatable.Header.Item>Policy</Datatable.Header.Item>
+      <Datatable.Header.Item>Annual Premium</Datatable.Header.Item>
+      <Datatable.Header.Item>End Date</Datatable.Header.Item>
+      <Datatable.Header.Item>Coverage Status</Datatable.Header.Item>
+      <Datatable.Header.Item>Action</Datatable.Header.Item>
+    </Datatable.Header>
+    <Datatable.Data>
+      {#each items as item (item.id)}
+        <Datatable.Data.Row on:click={() => gotoItemDetails(item)} clickable>
+          <Datatable.Data.Row.Item>{item.name}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{item.policy_id}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{item.annual_premium}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{item.coverage_end_date}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>{item.coverage_status}</Datatable.Data.Row.Item>
+          <Datatable.Data.Row.Item>
+            <Button url={policyDetails(item.policy_id)} on:click={preventRowClick}>view policy</Button>
+          </Datatable.Data.Row.Item>
+        </Datatable.Data.Row>
+      {/each}
+    </Datatable.Data>
+  </Datatable>
+{:else}
+  {#await delayLoading($loading)}
+    <p>Loading...</p>
+  {:then is_loading}
+    {#if $loading}
+      <p>Loading...</p>
+    {:else}
+      <p>No items found.</p>
+    {/if}
+  {/await}
+{/if}

--- a/src/pages/admin/_components/AuditsOrRepairTable.svelte
+++ b/src/pages/admin/_components/AuditsOrRepairTable.svelte
@@ -53,10 +53,6 @@ const preventRowClick = async () => {
   {#await delayLoading($loading)}
     <p>Loading...</p>
   {:then is_loading}
-    {#if $loading}
-      <p>Loading...</p>
-    {:else}
-      <p>No items found.</p>
-    {/if}
+    <p>{is_loading ? 'Loading...' : 'No items found.'}</p>
   {/await}
 {/if}

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -34,6 +34,10 @@ const checkForOpenClaims = async () => {
 
 const repair = async () => {
   await checkForOpenClaims()
+  if (itemsWithOpenClaim.length) {
+    setNotice(`Some items have active claims. Please resolve the claims before repairing the item records.`)
+    return
+  }
   try {
     await repairAudits(utcDate)
     setNotice('Succesfully repaired item records found to be at fault.')

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import AuditsOrRepairTable from './_components/AuditsOrRepairTable.svelte'
 import { audits, repairAudits, repairedAudits, runAudits } from 'data/audits'
-import { isItemWithActiveClaim, PolicyItem } from 'data/items'
+import type { PolicyItem } from 'data/items'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { metatags } from '@roxi/routify'
 import { Button, Page, setNotice } from '@silintl/ui-components'
@@ -20,12 +20,13 @@ $: haveRepairResults = repairedItems?.length
 $: repairIsDisabled = !haveAuditResults || !!haveRepairResults || !!itemsWithOpenClaim.length
 
 const onClick = () => {
+  itemsWithOpenClaim = []
   runAudits(utcDate)
 }
 
-const checkForOpenClaims = async () => {
+const checkForOpenClaims = () => {
   for (let item of auditItems) {
-    if (await isItemWithActiveClaim(item.id, item.policy_id)) {
+    if (!item.can_be_updated) {
       itemsWithOpenClaim.push(item)
       itemsWithOpenClaim = itemsWithOpenClaim
     }
@@ -33,7 +34,7 @@ const checkForOpenClaims = async () => {
 }
 
 const repair = async () => {
-  await checkForOpenClaims()
+  checkForOpenClaims()
   if (itemsWithOpenClaim.length) {
     setNotice(`Some items have active claims. Please resolve the claims before repairing the item records.`)
     return

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -30,7 +30,7 @@ const repair = async () => {
 }
 
 onMount(() => {
-  runAudits(utcDate)
+  haveAuditResults || runAudits(utcDate)
 })
 </script>
 

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -1,35 +1,22 @@
 <script lang="ts">
-import { delayLoading, loading } from 'components/progress'
-import type { PolicyItem } from 'data/items'
+import AuditsOrRepairTable from './_components/AuditsOrRepairTable.svelte'
 import { audits, repairAudits, repairedAudits, runAudits } from 'data/audits'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { itemDetails, policyDetails } from 'helpers/routes'
 import { isEqual } from 'lodash-es'
-import { goto, metatags } from '@roxi/routify'
-import { Button, Datatable, Page, setNotice } from '@silintl/ui-components'
+import { metatags } from '@roxi/routify'
+import { Button, Page, setNotice } from '@silintl/ui-components'
 
 metatags.title = formatPageTitle('Admin > Audit')
 
-let canViewItemDetails = true
 let utcDate = new Date().toISOString().split('T')[0]
 
-$: items = $audits?.items || []
-$: haveAuditResults = $audits?.items?.length
+$: auditItems = $audits?.items || []
+$: repairedItems = $repairedAudits?.items || []
+$: haveAuditResults = auditItems?.length
+$: haveRepairResults = repairedItems?.length
 
 const onClick = () => {
   runAudits(utcDate)
-}
-
-const gotoItemDetails = (item: PolicyItem) => {
-  if (canViewItemDetails) {
-    $goto(itemDetails(item.policy_id, item.id))
-  } else {
-    canViewItemDetails = true
-  }
-}
-
-const preventRowClick = async () => {
-  canViewItemDetails = false
 }
 
 const repair = async () => {
@@ -41,7 +28,6 @@ const repair = async () => {
         ? `All item records found to be at fault have been repaired.`
         : `Some item records found to be at fault were not repaired. Try running another audit.`
     )
-    items = $repairedAudits.items
   } catch {
     setNotice(`There was an error repairing the item records. Please try again.`)
   }
@@ -49,47 +35,22 @@ const repair = async () => {
 </script>
 
 <Page>
-  <h4>Audit Results (Items that were incorrectly renewed and billed)</h4>
+  <h4>Audits results (items that were incorrectly renewed and billed)</h4>
 
   <div class="my-1">
     <Button class="mr-1" raised on:click={onClick}>run audits</Button>
 
-    <Button outlined on:click={repair} disabled={!haveAuditResults}>repair</Button>
+    <Button prependIcon="build" outlined on:click={repair} disabled={!haveAuditResults}>repair</Button>
   </div>
-  {#if items.length}
-    <Datatable>
-      <Datatable.Header>
-        <Datatable.Header.Item>Name</Datatable.Header.Item>
-        <Datatable.Header.Item>Policy</Datatable.Header.Item>
-        <Datatable.Header.Item>Annual Premium</Datatable.Header.Item>
-        <Datatable.Header.Item>End Date</Datatable.Header.Item>
-        <Datatable.Header.Item>Coverage Status</Datatable.Header.Item>
-        <Datatable.Header.Item>Action</Datatable.Header.Item>
-      </Datatable.Header>
-      <Datatable.Data>
-        {#each items as item (item.id)}
-          <Datatable.Data.Row on:click={() => gotoItemDetails(item)} clickable>
-            <Datatable.Data.Row.Item>{item.name}</Datatable.Data.Row.Item>
-            <Datatable.Data.Row.Item>{item.policy_id}</Datatable.Data.Row.Item>
-            <Datatable.Data.Row.Item>{item.annual_premium}</Datatable.Data.Row.Item>
-            <Datatable.Data.Row.Item>{item.coverage_end_date}</Datatable.Data.Row.Item>
-            <Datatable.Data.Row.Item>{item.coverage_status}</Datatable.Data.Row.Item>
-            <Datatable.Data.Row.Item>
-              <Button url={policyDetails(item.policy_id)} on:click={preventRowClick}>view policy</Button>
-            </Datatable.Data.Row.Item>
-          </Datatable.Data.Row>
-        {/each}
-      </Datatable.Data>
-    </Datatable>
-  {:else}
-    {#await delayLoading($loading)}
-      <p>Loading...</p>
-    {:then is_loading}
-      {#if $loading}
-        <p>Loading...</p>
-      {:else}
-        <p>No items found.</p>
-      {/if}
-    {/await}
+  <AuditsOrRepairTable items={auditItems} />
+
+  {#if haveRepairResults}
+    <h4>Repair results (item records that have been repaired)</h4>
+    <div class="my-1">
+      <Button class="mr-1" raised on:click={onClick}>run audits</Button>
+
+      <Button prependIcon="build" outlined on:click={repair} disabled={!haveAuditResults}>repair</Button>
+    </div>
+    <AuditsOrRepairTable items={repairedItems} />
   {/if}
 </Page>

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -46,11 +46,7 @@ const repair = async () => {
 
   {#if haveRepairResults}
     <h4>Repair results (item records that have been repaired)</h4>
-    <div class="my-1">
-      <Button class="mr-1" raised on:click={onClick}>run audits</Button>
 
-      <Button prependIcon="build" outlined on:click={repair} disabled={!haveAuditResults}>repair</Button>
-    </div>
     <AuditsOrRepairTable items={repairedItems} />
   {/if}
 </Page>

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -35,7 +35,7 @@ const preventRowClick = async () => {
 const repair = async () => {
   try {
     await repairAudits(utcDate)
-    const responseIsEqualToAudits = isEqual($audits, $repairedAudits)
+    const responseIsEqualToAudits = isEqual($audits.Items, $repairedAudits.Items)
     setNotice(
       responseIsEqualToAudits
         ? `All item records found to be at fault have been repaired.`

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -2,9 +2,9 @@
 import AuditsOrRepairTable from './_components/AuditsOrRepairTable.svelte'
 import { audits, repairAudits, repairedAudits, runAudits } from 'data/audits'
 import { formatPageTitle } from 'helpers/pageTitle'
-import { isEqual } from 'lodash-es'
 import { metatags } from '@roxi/routify'
 import { Button, Page, setNotice } from '@silintl/ui-components'
+import { onMount } from 'svelte'
 
 metatags.title = formatPageTitle('Admin > Audit')
 
@@ -28,6 +28,10 @@ const repair = async () => {
     setNotice('There was an error repairing the item records. Please try again.')
   }
 }
+
+onMount(() => {
+  runAudits(utcDate)
+})
 </script>
 
 <Page>

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+import { loading } from 'components/progress'
+import type { PolicyItem } from 'data/items'
+import { AuditResult, runAudits } from 'data/audits'
+import { formatPageTitle } from 'helpers/pageTitle'
+import { itemDetails, policyDetails } from 'helpers/routes'
+import { goto, metatags } from '@roxi/routify'
+import { onMount } from 'svelte'
+import { Button, Datatable, Page, setNotice } from '@silintl/ui-components'
+
+metatags.title = formatPageTitle('Admin > Audit')
+
+let auditResult: AuditResult
+let canViewItemDetails = true
+let utcDate = new Date().toISOString().split('T')[0]
+
+$: items = auditResult?.Items || [
+  {
+    accountable_person: 'asdfsdfa',
+    annual_premium: 12,
+    category: 'asdfasdf' /*ItemCategory*/,
+    country: 'sdfasdfs',
+    coverage_amount: 'number',
+    coverage_end_date: 'string' /*Date*/,
+    coverage_start_date: 'string' /* yyyy-mm-dd Date */,
+    coverage_status: 'ItemCoverageStatus',
+    created_at: 'string' /*Date*/,
+    description: 'string',
+    id: 'string',
+    in_storage: 'boolean',
+    make: 'string',
+    model: 'string',
+    name: 'string',
+    policy_id: 'string',
+    prorated_annual_premium: 12,
+    risk_category: 'RiskCategory',
+    serial_number: 'string',
+    status_change: 'string',
+    status_reason: 'string',
+    updated_at: 'string' /*Date*/,
+  },
+]
+
+onMount(async () => {
+  auditResult = await runAudits(utcDate)
+})
+
+const gotoItemDetails = (item: PolicyItem) => {
+  if (canViewItemDetails) {
+    $goto(itemDetails(item.policy_id, item.id))
+  } else {
+    canViewItemDetails = true
+  }
+}
+
+const preventRowClick = async () => {
+  canViewItemDetails = false
+}
+
+const repair = async (item: PolicyItem) => {
+  //TODO: repair the item using post /repair endpoint
+  console.log('repairing', item.name)
+
+  setNotice(`Item ${item.name} has been repaired.`)
+}
+</script>
+
+<Page>
+  <div class="flex justify-between align-items-center">
+    <h4>Audit Results (Items that were incorrectly renewed and billed)</h4>
+
+    <Button raised on:click={repair} disabled={!items.length}>repair</Button>
+  </div>
+  {#if items.length}
+    <Datatable>
+      <Datatable.Header>
+        <Datatable.Header.Item>Name</Datatable.Header.Item>
+        <Datatable.Header.Item>Policy</Datatable.Header.Item>
+        <Datatable.Header.Item>Annual Premium</Datatable.Header.Item>
+        <Datatable.Header.Item>End Date</Datatable.Header.Item>
+        <Datatable.Header.Item>Coverage Status</Datatable.Header.Item>
+        <Datatable.Header.Item>Action</Datatable.Header.Item>
+      </Datatable.Header>
+      <Datatable.Data>
+        {#each items as item (item.id)}
+          <Datatable.Data.Row on:click={() => gotoItemDetails(item)} clickable>
+            <Datatable.Data.Row.Item>{item.name}</Datatable.Data.Row.Item>
+            <Datatable.Data.Row.Item>{item.policy_id}</Datatable.Data.Row.Item>
+            <Datatable.Data.Row.Item>{item.annual_premium}</Datatable.Data.Row.Item>
+            <Datatable.Data.Row.Item>{item.coverage_end_date}</Datatable.Data.Row.Item>
+            <Datatable.Data.Row.Item>{item.coverage_status}</Datatable.Data.Row.Item>
+            <Datatable.Data.Row.Item>
+              <Button url={policyDetails(item.policy_id)} on:click={preventRowClick}>view policy</Button>
+            </Datatable.Data.Row.Item>
+          </Datatable.Data.Row>
+        {/each}
+      </Datatable.Data>
+    </Datatable>
+  {:else if $loading}
+    <p>Loading...</p>
+  {:else}
+    <p>No items found.</p>
+  {/if}
+</Page>

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { loading } from 'components/progress'
+import { delayLoading, loading } from 'components/progress'
 import type { PolicyItem } from 'data/items'
 import { audits, runAudits } from 'data/audits'
 import { formatPageTitle } from 'helpers/pageTitle'
@@ -72,9 +72,15 @@ const repair = async () => {
         {/each}
       </Datatable.Data>
     </Datatable>
-  {:else if $loading}
-    <p>Loading...</p>
   {:else}
-    <p>No items found.</p>
+    {#await delayLoading($loading)}
+      <p>Loading...</p>
+    {:then is_loading}
+      {#if $loading}
+        <p>Loading...</p>
+      {:else}
+        <p>No items found.</p>
+      {/if}
+    {/await}
   {/if}
 </Page>

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -14,6 +14,7 @@ $: auditItems = $audits?.items || []
 $: repairedItems = $repairedAudits?.items || []
 $: haveAuditResults = auditItems?.length
 $: haveRepairResults = repairedItems?.length
+$: repairIsDisabled = !haveAuditResults || !!haveRepairResults
 
 const onClick = () => {
   runAudits(utcDate)
@@ -40,7 +41,7 @@ const repair = async () => {
   <div class="my-1">
     <Button class="mr-1" raised on:click={onClick}>run audits</Button>
 
-    <Button prependIcon="build" outlined on:click={repair} disabled={!haveAuditResults}>repair</Button>
+    <Button prependIcon="build" outlined on:click={repair} disabled={repairIsDisabled}>repair</Button>
   </div>
   <AuditsOrRepairTable items={auditItems} />
 

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -13,8 +13,8 @@ metatags.title = formatPageTitle('Admin > Audit')
 let canViewItemDetails = true
 let utcDate = new Date().toISOString().split('T')[0]
 
-$: items = $audits?.Items || []
-$: haveAuditResults = $audits?.Items?.length
+$: items = $audits?.items || []
+$: haveAuditResults = $audits?.items?.length
 
 const onClick = () => {
   runAudits(utcDate)
@@ -35,13 +35,13 @@ const preventRowClick = async () => {
 const repair = async () => {
   try {
     await repairAudits(utcDate)
-    const responseIsEqualToAudits = isEqual($audits.Items, $repairedAudits.Items)
+    const responseIsEqualToAudits = isEqual($audits.items, $repairedAudits.items)
     setNotice(
       responseIsEqualToAudits
         ? `All item records found to be at fault have been repaired.`
         : `Some item records found to be at fault were not repaired. Try running another audit.`
     )
-    items = $repairedAudits.Items
+    items = $repairedAudits.items
   } catch {
     setNotice(`There was an error repairing the item records. Please try again.`)
   }

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -1,49 +1,22 @@
 <script lang="ts">
 import { loading } from 'components/progress'
 import type { PolicyItem } from 'data/items'
-import { AuditResult, runAudits } from 'data/audits'
+import { audits, runAudits } from 'data/audits'
 import { formatPageTitle } from 'helpers/pageTitle'
 import { itemDetails, policyDetails } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
-import { onMount } from 'svelte'
 import { Button, Datatable, Page, setNotice } from '@silintl/ui-components'
 
 metatags.title = formatPageTitle('Admin > Audit')
 
-let auditResult: AuditResult
 let canViewItemDetails = true
 let utcDate = new Date().toISOString().split('T')[0]
 
-$: items = auditResult?.Items || [
-  {
-    accountable_person: 'asdfsdfa',
-    annual_premium: 12,
-    category: 'asdfasdf' /*ItemCategory*/,
-    country: 'sdfasdfs',
-    coverage_amount: 'number',
-    coverage_end_date: 'string' /*Date*/,
-    coverage_start_date: 'string' /* yyyy-mm-dd Date */,
-    coverage_status: 'ItemCoverageStatus',
-    created_at: 'string' /*Date*/,
-    description: 'string',
-    id: 'string',
-    in_storage: 'boolean',
-    make: 'string',
-    model: 'string',
-    name: 'string',
-    policy_id: 'string',
-    prorated_annual_premium: 12,
-    risk_category: 'RiskCategory',
-    serial_number: 'string',
-    status_change: 'string',
-    status_reason: 'string',
-    updated_at: 'string' /*Date*/,
-  },
-]
+$: items = $audits?.Items || []
 
-onMount(async () => {
-  auditResult = await runAudits(utcDate)
-})
+const onClick = () => {
+  runAudits(utcDate)
+}
 
 const gotoItemDetails = (item: PolicyItem) => {
   if (canViewItemDetails) {
@@ -57,19 +30,22 @@ const preventRowClick = async () => {
   canViewItemDetails = false
 }
 
-const repair = async (item: PolicyItem) => {
+const repair = async () => {
   //TODO: repair the item using post /repair endpoint
-  console.log('repairing', item.name)
 
-  setNotice(`Item ${item.name} has been repaired.`)
+  setNotice(`All item records found to be at fault have been repaired.`)
+
+  items = []
 }
 </script>
 
 <Page>
-  <div class="flex justify-between align-items-center">
-    <h4>Audit Results (Items that were incorrectly renewed and billed)</h4>
+  <h4>Audit Results (Items that were incorrectly renewed and billed)</h4>
 
-    <Button raised on:click={repair} disabled={!items.length}>repair</Button>
+  <div class="my-1">
+    <Button class="mr-1" raised on:click={onClick}>run audits</Button>
+
+    <Button outlined on:click={repair} disabled={!items.length}>repair</Button>
   </div>
   {#if items.length}
     <Datatable>

--- a/src/pages/admin/audits.svelte
+++ b/src/pages/admin/audits.svelte
@@ -23,14 +23,9 @@ const onClick = () => {
 const repair = async () => {
   try {
     await repairAudits(utcDate)
-    const responseIsEqualToAudits = isEqual($audits.items, $repairedAudits.items)
-    setNotice(
-      responseIsEqualToAudits
-        ? `All item records found to be at fault have been repaired.`
-        : `Some item records found to be at fault were not repaired. Try running another audit.`
-    )
+    setNotice('Succesfully repaired item records found to be at fault.')
   } catch {
-    setNotice(`There was an error repairing the item records. Please try again.`)
+    setNotice('There was an error repairing the item records. Please try again.')
   }
 }
 </script>

--- a/src/validation/assertions.ts
+++ b/src/validation/assertions.ts
@@ -1,4 +1,6 @@
+import type { PolicyItem } from 'data/items'
 import { throwError } from '../error'
+import { capitalize } from 'lodash-es'
 
 export function assertHas(value: any, errorMessage: string): void {
   if (!value) {
@@ -44,4 +46,12 @@ export function assertEmailAddress(email: string, errorMessage: string): void {
   if (!simpleEmailRegex.test(email)) {
     throwError(errorMessage)
   }
+}
+
+export const assertItemsCanBeDeleted = (items: PolicyItem[]): void => {
+  items.forEach((item) => {
+    if (item.can_be_deleted === false) {
+      throwError(`${capitalize(item.name)} has an open claim, you cannot end coverage until it is resolved.`)
+    }
+  })
 }


### PR DESCRIPTION
- add /audits view
- add buttons to run audits and repairs
- add tables to show items found in audits and repairs
After the audit result has loaded
![image](https://user-images.githubusercontent.com/70765247/222334305-740ccb9d-ecb1-4681-b900-a114f87aa36b.png)
After running the repair
![image](https://user-images.githubusercontent.com/70765247/222334381-4580fb43-56ad-4433-b97c-5585c911ad9a.png)
Item had an active claim
![image](https://user-images.githubusercontent.com/70765247/222334859-4acca649-70fe-4acc-89e1-47d5cbcb9cf8.png)
To help admin find claims if action is needed
![image](https://user-images.githubusercontent.com/70765247/222359536-d2e8d935-7eba-4e6e-b074-d7131c09efaa.png)

