### PR TITLE
hide inactive entities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ start: install local-dev
 
 docker:
 	docker-compose run --rm app npm install
-	docker-compose up -d
-	docker-compose logs -f app
+	docker-compose run --rm --service-ports app
 
 install:
 	npm install

--- a/src/pages/policies/new.svelte
+++ b/src/pages/policies/new.svelte
@@ -20,8 +20,8 @@ let entityOptions: any = {}
 onMount(() => $entityCodes.length || loadEntityCodes())
 
 $: metatags.title = formatPageTitle('New Team Policy')
-$: $entityCodes.forEach((code) => {
-  entityOptions[`${code.code} - ${code.name}`] = code.code
+$: $entityCodes.filter(e => e.active && e.code != 'HH').forEach(e => {
+  entityOptions[`${e.code} - ${e.name}`] = e.code
 })
 $: entityCodeName = getEntityChoice(entityCode)
 


### PR DESCRIPTION
### Fixed
- Switch from using `docker-compose up` to `docker-compose run` for the `make docker` command.
- Filter out inactive and household entity codes for new policy form.