### PR TITLE
fix ItemForm allowing 0, move functions

### DIFF
--- a/src/components/ConvertCurrencyLink.svelte
+++ b/src/components/ConvertCurrencyLink.svelte
@@ -1,4 +1,4 @@
 To convert to USD, use
-<a class="mdc-theme--neutral" href="https://www.google.com/search?q=currency+converter" target="_blank"
+<a class="mdc-theme--neutral" href="https://www.google.com/search?q=currency+converter" target="_blank" rel="noreferrer"
   >this converter</a
 >.

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-import user, { isAdmin, User } from 'data/user'
 import ConvertCurrencyLink from '../ConvertCurrencyLink.svelte'
 import Description from '../Description.svelte'
-import MakeAndModelModal from 'MakeAndModelModal.svelte'
+import MakeAndModelModal from '../MakeAndModelModal.svelte'
 import ItemDeleteModal from '../ItemDeleteModal.svelte'
-import SelectAccountablePerson from '../SelectAccountablePerson.svelte'
 import { MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
 import { ItemCoverageStatus, NewItemFormData, PolicyItem, RiskCategoryNames, UpdateItemFormData } from 'data/items'
 import { categories, loadCategories, initialized as catItemsInitialized } from 'data/itemCategories'
+import user, { isAdmin, User } from 'data/user'
+import { areMakeAndModelRequired, validateForSubmit, validateForSave } from './items/itemFormHelpers'
+import SelectAccountablePerson from '../SelectAccountablePerson.svelte'
 import TextFieldWithLabel from '../TextFieldWithLabel.svelte'
-import { assertHas, assertIsLessOrEqual } from '../../validation/assertions'
 import { debounce } from 'lodash-es'
 import { Button, Card, Form, MoneyInput, Select, TextArea } from '@silintl/ui-components'
 import { createEventDispatcher } from 'svelte'
@@ -105,33 +105,10 @@ const onCategorySelectPopulated = () => {
   }
 }
 
-const validateOnSave = (formData: any) => {
-  assertHas(formData.accountablePersonId, 'Please Assign an Accountable Person')
-  assertHas(formData.categoryId, 'Please select a category')
-  assertHas(formData.name, 'Please specify a short name')
-
-  return true
-}
-
-const validate = (formData: any) => {
-  validateOnSave(formData)
-  assertHas(formData.marketValueUSD, 'Please specify the market value')
-  item.coverage_status !== ItemCoverageStatus.Draft &&
-    assertIsLessOrEqual(formData.marketValueUSD * 100, item.coverage_amount, 'Coverage amount cannot be increased')
-  return true
-}
-
-const areMakeAndModelRequired = () => {
-  return (
-    item.coverage_status !== ItemCoverageStatus.Approved &&
-    $categories.find((category) => category.id === categoryId)?.require_make_model
-  )
-}
-
-const onSubmit = (event: Event) => {
+const onSubmit = () => {
   formData = getFormData()
-  validate(formData)
-  if (!(make && model) && areMakeAndModelRequired()) {
+  validateForSubmit(item, formData)
+  if (!(make && model) && areMakeAndModelRequired(item, categoryId)) {
     makeModelIsOpen = true
   } else {
     dispatch('submit', formData)
@@ -140,7 +117,7 @@ const onSubmit = (event: Event) => {
 
 const saveForLater = (event?: Event, isAutoSaving = false) => {
   const formData = getFormData()
-  validateOnSave(formData)
+  validateForSave(formData)
   dispatch('save-for-later', { ...formData, isAutoSaving })
   event?.preventDefault()
 }
@@ -261,7 +238,7 @@ span.label {
   </p>
   <p>
     <span class="label">Value to cover (USD)<span class="error">*</span></span>
-    <MoneyInput minValue={'0'} bind:value={marketValueUSD} disabled={marketValueIsDisabled} required />
+    <MoneyInput bind:value={marketValueUSD} disabled={marketValueIsDisabled} required />
     <Description>
       <ConvertCurrencyLink />
     </Description>

--- a/src/components/forms/items/itemFormHelpers.ts
+++ b/src/components/forms/items/itemFormHelpers.ts
@@ -1,0 +1,28 @@
+import { categories } from 'data/itemCategories'
+import { ItemCoverageStatus, PolicyItem, NewItemFormData, UpdateItemFormData } from 'data/items'
+import { assertHas, assertIsLessOrEqual } from '../../../validation/assertions'
+import { get } from 'svelte/store'
+
+export const areMakeAndModelRequired = (item: PolicyItem, categoryId: string): boolean | undefined => {
+  return (
+    item.coverage_status !== ItemCoverageStatus.Approved &&
+    get(categories).find((category) => category.id === categoryId)?.require_make_model
+  )
+}
+
+export const validateForSave = (formData: NewItemFormData | UpdateItemFormData): void => {
+  assertHas(formData.accountablePersonId, 'Please Assign an Accountable Person')
+  assertHas(formData.categoryId, 'Please select a category')
+  assertHas(formData.name, 'Please specify a short name')
+}
+
+export const validateForSubmit = (item: PolicyItem, formData: NewItemFormData | UpdateItemFormData): void => {
+  validateForSave(formData)
+  assertIsLessOrEqual(0.01, Number(formData.marketValueUSD), 'Please specify the market value')
+  item.coverage_status !== ItemCoverageStatus.Draft &&
+    assertIsLessOrEqual(
+      Number(formData.marketValueUSD) * 100,
+      item.coverage_amount,
+      'Coverage amount cannot be increased'
+    )
+}


### PR DESCRIPTION
- prevent allowing `0` for `marketValue`
- move functions to a helper file
- fix a warning