### PR TITLE
Feature/report csv+zip

### DIFF
--- a/src/data/ledger.ts
+++ b/src/data/ledger.ts
@@ -5,8 +5,7 @@ import { writable } from 'svelte/store'
 
 export type LedgerReport = {
   id: string
-  file: CoverFile // Mixed all transactions (Sage)(original)
-  zip: CoverFile // Split transactions into files by type (NetSuite)
+  file: CoverFile
   type: string
   date: string
   is_cleared: boolean

--- a/src/data/ledger.ts
+++ b/src/data/ledger.ts
@@ -5,7 +5,8 @@ import { writable } from 'svelte/store'
 
 export type LedgerReport = {
   id: string
-  file: CoverFile
+  file: CoverFile // Mixed all transactions (Sage)(original)
+  zip: CoverFile // Split transactions into files by type (NetSuite)
   type: string
   date: string
   is_cleared: boolean

--- a/src/pages/admin/reports/[reportId].svelte
+++ b/src/pages/admin/reports/[reportId].svelte
@@ -73,9 +73,7 @@ dl {
     <dl>
       <dt>Report Date</dt>
       <dd>{formatFriendlyDate(report.date)}</dd>
-      <dt>
-        File
-      </dt>
+      <dt>File</dt>
       <dd><FileLink on:expired={getReport} file={report.file} /></dd>
       <dt>Cleared</dt>
       <dd>{report.is_cleared ? 'Yes' : 'No'}</dd>

--- a/src/pages/admin/reports/[reportId].svelte
+++ b/src/pages/admin/reports/[reportId].svelte
@@ -76,6 +76,10 @@ th {
         <td><FileLink on:expired={getReport} file={report.file} /></td>
       </tr>
       <tr>
+        <th>File</th>
+        <td><FileLink on:expired={getReport} file={report.file} /></td>
+      </tr>
+      <tr>
         <th>Cleared</th>
         <td>{report.is_cleared ? 'Yes' : 'No'}</td>
       </tr>

--- a/src/pages/admin/reports/[reportId].svelte
+++ b/src/pages/admin/reports/[reportId].svelte
@@ -45,6 +45,15 @@ th {
 th {
   text-align: left;
 }
+div:has(dl) {
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  row-gap: 1rem;
+  column-gap: clamp(2rem, 5vw, 6rem);
+  & * {
+    justify-content: start;
+  }
+}
 </style>
 
 <Page>
@@ -62,31 +71,19 @@ th {
   </div>
 
   <div>
-    <table>
-      <tr>
-        <th>Report Date</th>
-        <td>{formatFriendlyDate(report.date)}</td>
-      </tr>
-      <tr>
-        <th>Created At</th>
-        <td>{formatDateAndTime(report.created_at)}</td>
-      </tr>
-      <tr>
-        <th>File</th>
-        <td><FileLink on:expired={getReport} file={report.file} /></td>
-      </tr>
-      <tr>
-        <th>File</th>
-        <td><FileLink on:expired={getReport} file={report.file} /></td>
-      </tr>
-      <tr>
-        <th>Cleared</th>
-        <td>{report.is_cleared ? 'Yes' : 'No'}</td>
-      </tr>
-      <tr>
-        <th>Transactions</th>
-        <td>{report.transaction_count}</td>
-      </tr>
-    </table>
+    <dl>
+      <dt>Report Date</dt>
+      <dd>{formatFriendlyDate(report.date)}</dd>
+      <dt>Created At</dt>
+      <dd>{formatDateAndTime(report.created_at)}</dd>
+      <dt>Download for Sage<br />Mixed transations</dt>
+      <dd><FileLink on:expired={getReport} file={report.file} /></dd>
+      <dt>Download for NetSuite<br />Split transations</dt>
+      <dd><FileLink on:expired={getReport} file={report.file} /></dd>
+      <dt>Cleared</dt>
+      <dd>{report.is_cleared ? 'Yes' : 'No'}</dd>
+      <dt>Transactions</dt>
+      <dd>{report.transaction_count}</dd>
+    </dl>
   </div>
 </Page>

--- a/src/pages/admin/reports/[reportId].svelte
+++ b/src/pages/admin/reports/[reportId].svelte
@@ -37,49 +37,52 @@ async function getReport() {
 </script>
 
 <style>
-td,
-th {
-  padding: 0.25ex;
+header {
+  margin-block-end: 2rem;
 }
-
-th {
-  text-align: left;
+dd {
+  margin-inline-start: clamp(0.5rem, 2vw, 2rem);
 }
-div:has(dl) {
+dl {
+  grid-column: span 1;
   display: grid;
   grid-template-columns: repeat(2, max-content);
-  row-gap: 1rem;
-  column-gap: clamp(2rem, 5vw, 6rem);
-  & * {
-    justify-content: start;
-  }
+  align-content: start;
+  margin: unset;
+  gap: 1rem;
 }
 </style>
 
 <Page>
-  <div class="flex justify-between align-items-center">
-    <h4>{report.type} Report</h4>
-    <Button
-      on:click={() => {
-        alertOpen = true
-      }}>Reconcile</Button
-    >
-
-    <Dialog.Alert open={alertOpen} {buttons} defaultAction="cancel" {title} on:chosen={(e) => handleDialog(e.detail)}>
-      {message}
-    </Dialog.Alert>
-  </div>
+  <header>
+    <div class="flex justify-between align-items-center">
+      <h1>{report.type} Report</h1>
+      <Button
+        on:click={() => {
+          alertOpen = true
+        }}>Reconcile</Button
+      >
+      <Dialog.Alert open={alertOpen} {buttons} defaultAction="cancel" {title} on:chosen={(e) => handleDialog(e.detail)}>
+        {message}
+      </Dialog.Alert>
+    </div>
+    <div class="fs-14">Created {formatDateAndTime(report.created_at)}</div>
+  </header>
 
   <div>
     <dl>
       <dt>Report Date</dt>
       <dd>{formatFriendlyDate(report.date)}</dd>
-      <dt>Created At</dt>
-      <dd>{formatDateAndTime(report.created_at)}</dd>
-      <dt>Download for Sage<br />Mixed transations</dt>
+      <dt>
+        File for Sage
+        <div class="fs-12">Mixed transations</div>
+      </dt>
       <dd><FileLink on:expired={getReport} file={report.file} /></dd>
-      <dt>Download for NetSuite<br />Split transations</dt>
-      <dd><FileLink on:expired={getReport} file={report.file} /></dd>
+      <dt>
+        File for NetSuite
+        <div class="fs-12">Split transations</div>
+      </dt>
+      <dd><FileLink on:expired={getReport} file={report.zip} /></dd>
       <dt>Cleared</dt>
       <dd>{report.is_cleared ? 'Yes' : 'No'}</dd>
       <dt>Transactions</dt>

--- a/src/pages/admin/reports/[reportId].svelte
+++ b/src/pages/admin/reports/[reportId].svelte
@@ -74,15 +74,9 @@ dl {
       <dt>Report Date</dt>
       <dd>{formatFriendlyDate(report.date)}</dd>
       <dt>
-        File for Sage
-        <div class="fs-12">Mixed transations</div>
+        File
       </dt>
       <dd><FileLink on:expired={getReport} file={report.file} /></dd>
-      <dt>
-        File for NetSuite
-        <div class="fs-12">Split transations</div>
-      </dt>
-      <dd><FileLink on:expired={getReport} file={report.zip} /></dd>
       <dt>Cleared</dt>
       <dd>{report.is_cleared ? 'Yes' : 'No'}</dd>
       <dt>Transactions</dt>


### PR DESCRIPTION
[CVR-613](https://itse.youtrack.cloud/issue/CVR-613) On the admin report page, add a new file download line. Describe the difference between the different downloads:

- The original download is for Sage and will give a CSV of all transactions (as before)
- The second download is for NetSuite and will give a ZIP of transactions split into different CSVs by type. I added a field to ReportLedger for this file, which will need to be populated before release (TODO @jason-jackson).

I also improved the semantics and formatting of the page.

There was already a bug where the file link will sometimes stop being a link. Even though it loads as a link, when I go away and come back, it's no longer a link—not clickable, blue, or underlined! I don't know whether it had been reported or now. I haven't been able to reliably replicate the behavior.

Devon wrote
> Based on your screenshot, where the .csv file is located, I'd like to move forward with just listing the csv and the zip file in that column.  Whether it is turned into a dropdown button for each report created or just put a <br> after the csv is up to you.  If the entire row is currently linked to download the CSV, then we'll need to adjust that so just the csv and zip files are linked.  This is a short-term temporary change that only affects Admins, so I'd prefer it being completed as simply and quickly as possible.

![screenshot_2023-07-27_at_11 06 54_pm](https://github.com/silinternational/cover-ui/assets/441789/806d5d2e-2f6e-400d-98f4-6eed09088e8d)
<img width="971" alt="Screenshot 2023-07-28 at 10 07 43 AM" src="https://github.com/silinternational/cover-ui/assets/441789/6436c412-7f17-491f-bbd4-e15b3e4e1402">
