### PR TITLE
add row with None in ItemsTable

### DIFF
--- a/src/components/Datatable/PolicyItems/ItemsTable.svelte
+++ b/src/components/Datatable/PolicyItems/ItemsTable.svelte
@@ -326,11 +326,11 @@ const getStatusClass = (status: ItemCoverageStatus) =>
         </RowItem>
       </Datatable.Data.Row>
     {:else}
-    <tr>
-      <RowItem className="p-1">
-        <i>None</i>
-      </RowItem>
-    </tr>
+      <tr>
+        <RowItem className="p-1">
+          <i>None</i>
+        </RowItem>
+      </tr>
     {/each}
   </Datatable.Data>
 </Datatable>

--- a/src/components/Datatable/PolicyItems/ItemsTable.svelte
+++ b/src/components/Datatable/PolicyItems/ItemsTable.svelte
@@ -325,6 +325,12 @@ const getStatusClass = (status: ItemCoverageStatus) =>
           </div>
         </RowItem>
       </Datatable.Data.Row>
+    {:else}
+    <tr>
+      <RowItem className="p-1">
+        <i>None</i>
+      </RowItem>
+    </tr>
     {/each}
   </Datatable.Data>
 </Datatable>


### PR DESCRIPTION
- I couldn't use the full Datatable.Row component because mdc was throwing an error which I could not decipher.
![image](https://github.com/silinternational/cover-ui/assets/70765247/b9d52a45-2c81-4fac-836d-2bf228dcc9fc)