### PR TITLE
CVR-705 (c): Update other checkout details re: monthly vs yearly

### DIFF
--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -27,7 +27,7 @@ $: $policies && (policy = getPolicyById(policyId))
 $: statusText = getItemStatusText(item)
 $: status = (item.coverage_status || '') as ItemCoverageStatus
 $: showRevisionMessage = item.status_reason && status === ItemCoverageStatus.Revision
-$: startDate = formatDate(item.coverage_start_date)
+$: startDate = formatDate(item?.coverage_start_date) || '(when approved)'
 $: endDate = formatDate(item.coverage_end_date)
 $: renewDate = getRenewalDate()
 $: commonDetails = {

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -10,7 +10,7 @@ import {
 } from 'data/items'
 import { getPolicyById, loadPolicy, policies, Policy, PolicyType } from 'data/policies'
 import { isBeforeMonthlyCutoff } from 'helpers/coverage'
-import { formatDate } from 'helpers/dates'
+import { formatDate, startOfFutureMonth } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 import InfoBoxModal from './InfoBoxModal.svelte'
 import { formatDistanceToNow } from 'date-fns'
@@ -71,23 +71,14 @@ const getItemStatusText = (item: PolicyItem) => {
 
 const getMonthlyRenewalDate = (item: PolicyItem): string => {
   if (itemIsApproved(item)) {
-    const nextMonth = new Date()
-    nextMonth.setMonth(nextMonth.getMonth() + 1)
-    nextMonth.setDate(1)
-    return formatDate(nextMonth.toISOString())
+    return startOfFutureMonth(1)
   }
 
   if (isItemDraft(item)) {
     if (isBeforeMonthlyCutoff()) {
-      const nextMonth = new Date()
-      nextMonth.setMonth(nextMonth.getMonth() + 1)
-      nextMonth.setDate(1)
-      return formatDate(nextMonth.toISOString())
+      return startOfFutureMonth(1)
     } else {
-      const monthAfterNext = new Date()
-      monthAfterNext.setMonth(monthAfterNext.getMonth() + 2)
-      monthAfterNext.setDate(1)
-      return formatDate(monthAfterNext.toISOString())
+      return startOfFutureMonth(2)
     }
   }
 

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-import Banner from './Banner.svelte'
 import ItemBanner from './banners/ItemBanner.svelte'
 import MessageBanner from './banners/MessageBanner.svelte'
 import { PolicyItem, ItemCoverageStatus } from 'data/items'
 import { getPolicyById, loadPolicy, policies, Policy, PolicyType } from 'data/policies'
-import { formatDate } from '../helpers/dates'
+import { formatDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 import InfoBoxModal from './InfoBoxModal.svelte'
 import { formatDistanceToNow } from 'date-fns'

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -16,7 +16,6 @@ export let policyId: string
 export let isAdmin: boolean = false
 
 let policy: Policy
-let renewYear = new Date().getFullYear() + 1
 
 const showInfoBox: boolean[] = []
 const assignedTo = 'Accountable Person'
@@ -30,7 +29,7 @@ $: status = (item.coverage_status || '') as ItemCoverageStatus
 $: showRevisionMessage = item.status_reason && status === ItemCoverageStatus.Revision
 $: startDate = formatDate(item.coverage_start_date)
 $: endDate = formatDate(item.coverage_end_date)
-$: renewDate = formatDate(`${renewYear}-01-01`)
+$: renewDate = getRenewalDate()
 $: commonDetails = {
   [assignedTo]: item?.accountable_person?.name,
   Location: item.accountable_person?.country || item.country,
@@ -61,6 +60,11 @@ const getItemStatusText = (item: PolicyItem) => {
   const statusChangeStr = item.status_change ? `${item.status_change} ` : updatedAtStr ? 'Submitted ' : ''
 
   return statusChangeStr + updatedAtStr
+}
+
+const getRenewalDate = (): string => {
+  const renewYear = new Date().getFullYear() + 1
+  return formatDate(`${renewYear}-01-01`)
 }
 
 const getPremiumDescription = (item: PolicyItem | undefined): string => {

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -49,7 +49,7 @@ $: minimumDeductible = item?.category?.minimum_deductible
 $: minimumDeductibleDescription = minimumDeductible ? `(subject to ${formatMoney(minimumDeductible)} minimum)` : ''
 $: moneyDetails = {
   Value: formatMoney(item.coverage_amount),
-  Premium: `${formatMoney(item.annual_premium)} / yr`,
+  Premium: getPremiumDescription(item),
   Deductible: `5% ${minimumDeductibleDescription}`.trim(),
 }
 $: sidebarDetailsArray =
@@ -62,6 +62,10 @@ const getItemStatusText = (item: PolicyItem) => {
   const statusChangeStr = item.status_change ? `${item.status_change} ` : updatedAtStr ? 'Submitted ' : ''
 
   return statusChangeStr + updatedAtStr
+}
+
+const getPremiumDescription = (item: PolicyItem | undefined): string => {
+  return `${formatMoney(item.annual_premium)} / yr`
 }
 
 const toggleModal = (i: number) => (showInfoBox[i] = !showInfoBox[i])

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -68,12 +68,14 @@ const getPremiumDescription = (item: PolicyItem | undefined): string => {
     return ''
   }
 
-  if (item.billing_period === BillingPeriod.Monthly) {
+  if (isMonthly(item)) {
     return `${formatMoney(item.monthly_premium)} / month`
   }
 
   return `${formatMoney(item.annual_premium)} / year`
 }
+
+const isMonthly = (item: PolicyItem | undefined) => item?.billing_period === BillingPeriod.Monthly
 
 const toggleModal = (i: number) => (showInfoBox[i] = !showInfoBox[i])
 </script>

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import ItemBanner from './banners/ItemBanner.svelte'
 import MessageBanner from './banners/MessageBanner.svelte'
-import { PolicyItem, ItemCoverageStatus } from 'data/items'
+import { BillingPeriod, ItemCoverageStatus, PolicyItem } from 'data/items'
 import { getPolicyById, loadPolicy, policies, Policy, PolicyType } from 'data/policies'
 import { formatDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
@@ -64,7 +64,15 @@ const getItemStatusText = (item: PolicyItem) => {
 }
 
 const getPremiumDescription = (item: PolicyItem | undefined): string => {
-  return `${formatMoney(item.annual_premium)} / yr`
+  if (!item || !item.id) {
+    return ''
+  }
+
+  if (item.billing_period === BillingPeriod.Monthly) {
+    return `${formatMoney(item.monthly_premium)} / month`
+  }
+
+  return `${formatMoney(item.annual_premium)} / year`
 }
 
 const toggleModal = (i: number) => (showInfoBox[i] = !showInfoBox[i])

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -34,7 +34,7 @@ $: $policies && (policy = getPolicyById(policyId))
 $: statusText = getItemStatusText(item)
 $: status = (item.coverage_status || '') as ItemCoverageStatus
 $: showRevisionMessage = item.status_reason && status === ItemCoverageStatus.Revision
-$: startDate = formatDate(item?.coverage_start_date) || '(when approved)'
+$: startDate = formatDate(item.coverage_start_date) || '(when approved)'
 $: endDate = formatDate(item.coverage_end_date)
 $: renewDate = getRenewalDate(item)
 $: commonDetails = {

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -3,7 +3,7 @@ import ItemBanner from './banners/ItemBanner.svelte'
 import MessageBanner from './banners/MessageBanner.svelte'
 import { ItemCoverageStatus, PolicyItem } from 'data/items'
 import { getPolicyById, loadPolicy, policies, Policy, PolicyType } from 'data/policies'
-import { getPremiumDescription, getRenewalDate } from 'helpers/coverage'
+import { getPremiumDescription, getRenewalDate, getStartDate } from 'helpers/coverage'
 import { formatDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 import InfoBoxModal from './InfoBoxModal.svelte'
@@ -28,7 +28,7 @@ $: $policies && (policy = getPolicyById(policyId))
 $: statusText = getItemStatusText(item)
 $: status = (item.coverage_status || '') as ItemCoverageStatus
 $: showRevisionMessage = item.status_reason && status === ItemCoverageStatus.Revision
-$: startDate = formatDate(item.coverage_start_date) || '(when approved)'
+$: startDate = getStartDate(item)
 $: endDate = formatDate(item.coverage_end_date)
 $: renewDate = getRenewalDate(item)
 $: commonDetails = {

--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -1,16 +1,10 @@
 <script lang="ts">
 import ItemBanner from './banners/ItemBanner.svelte'
 import MessageBanner from './banners/MessageBanner.svelte'
-import {
-  BillingPeriod,
-  isItemDraft,
-  ItemCoverageStatus,
-  itemIsApproved,
-  PolicyItem
-} from 'data/items'
+import { ItemCoverageStatus, PolicyItem } from 'data/items'
 import { getPolicyById, loadPolicy, policies, Policy, PolicyType } from 'data/policies'
-import { isBeforeMonthlyCutoff } from 'helpers/coverage'
-import { formatDate, startOfFutureMonth } from 'helpers/dates'
+import { getPremiumDescription, getRenewalDate } from 'helpers/coverage'
+import { formatDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 import InfoBoxModal from './InfoBoxModal.svelte'
 import { formatDistanceToNow } from 'date-fns'
@@ -68,53 +62,6 @@ const getItemStatusText = (item: PolicyItem) => {
 
   return statusChangeStr + updatedAtStr
 }
-
-const getMonthlyRenewalDate = (item: PolicyItem): string => {
-  if (itemIsApproved(item)) {
-    return startOfFutureMonth(1)
-  }
-
-  if (isItemDraft(item)) {
-    if (isBeforeMonthlyCutoff()) {
-      return startOfFutureMonth(1)
-    } else {
-      return startOfFutureMonth(2)
-    }
-  }
-
-  return ''
-}
-
-const getRenewalDate = (item: PolicyItem | undefined): string => {
-  if (!item || !item.id) {
-    return ''
-  }
-
-  if (isMonthly(item)) {
-    return getMonthlyRenewalDate(item)
-  }
-
-  return getYearlyRenewalDate(item)
-}
-
-const getPremiumDescription = (item: PolicyItem | undefined): string => {
-  if (!item || !item.id) {
-    return ''
-  }
-
-  if (isMonthly(item)) {
-    return `${formatMoney(item.monthly_premium)} / month`
-  }
-
-  return `${formatMoney(item.annual_premium)} / year`
-}
-
-const getYearlyRenewalDate = (item: PolicyItem): string => {
-  const renewYear = new Date().getFullYear() + 1
-  return formatDate(`${renewYear}-01-01`)
-}
-
-const isMonthly = (item: PolicyItem) => item.billing_period === BillingPeriod.Monthly
 
 const toggleModal = (i: number) => (showInfoBox[i] = !showInfoBox[i])
 </script>

--- a/src/components/checkout/MonthlyCheckoutMessage.svelte
+++ b/src/components/checkout/MonthlyCheckoutMessage.svelte
@@ -12,7 +12,7 @@ $: monthlyPremium = item.monthly_premium
 </script>
 
 <span>
-  {#if isBeforeMonthlyCutoff}
+  {#if isBeforeMonthlyCutoff()}
     Pay {formatMoney(monthlyPremium)} from {org} account {accountOrHouseholdId}
     each month.
   {:else}

--- a/src/components/checkout/MonthlyCheckoutMessage.svelte
+++ b/src/components/checkout/MonthlyCheckoutMessage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { PolicyItem } from 'data/items'
+import { isBeforeMonthlyCutoff } from 'helpers/coverage'
 import { formatDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 
@@ -9,8 +10,6 @@ export let item: PolicyItem
 export let org: string
 
 const today = new Date()
-
-const isBeforeMonthlyCutoff = today.getUTCDate() < 20
 
 const nextMonth = new Date()
 nextMonth.setMonth(today.getMonth() + 1)

--- a/src/components/checkout/MonthlyCheckoutMessage.svelte
+++ b/src/components/checkout/MonthlyCheckoutMessage.svelte
@@ -1,18 +1,12 @@
 <script lang="ts">
 import type { PolicyItem } from 'data/items'
 import { isBeforeMonthlyCutoff } from 'helpers/coverage'
-import { formatDate } from 'helpers/dates'
+import { startOfFutureMonth } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 
 export let accountOrHouseholdId: string
 export let item: PolicyItem
 export let org: string
-
-const today = new Date()
-
-const thirdMonth = new Date()
-thirdMonth.setMonth(today.getMonth() + 2)
-thirdMonth.setDate(1)
 
 $: monthlyPremium = item.monthly_premium
 </script>
@@ -23,7 +17,7 @@ $: monthlyPremium = item.monthly_premium
     each month.
   {:else}
     Pay {formatMoney(monthlyPremium)} from {org} account {accountOrHouseholdId}
-    each month, starting {formatDate(thirdMonth.toISOString())}. <br />
+    each month, starting {startOfFutureMonth(2)}. <br />
     <strong>NOTE:</strong> Coverage will begin when approved.
   {/if}
 </span>

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -6,7 +6,14 @@ import ItemDeleteModal from '../ItemDeleteModal.svelte'
 import YearInput from '../YearInput.svelte'
 import { MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
-import { ItemCoverageStatus, NewItemFormData, PolicyItem, RiskCategoryNames, UpdateItemFormData } from 'data/items'
+import {
+  isItemDraft,
+  ItemCoverageStatus,
+  NewItemFormData,
+  PolicyItem,
+  RiskCategoryNames,
+  UpdateItemFormData
+} from 'data/items'
 import { categories, loadCategories, initialized as catItemsInitialized } from 'data/itemCategories'
 import user, { isAdmin, User } from 'data/user'
 import { areMakeAndModelRequired, assembleStatementNameDefault, validateForSubmit, validateForSave } from './items/itemFormHelpers'
@@ -57,7 +64,7 @@ let userCustomizedStatementName = false
 
 $: country = item?.accountable_person?.country || country
 $: !$catItemsInitialized && loadCategories()
-$: itemIsDraft = item.coverage_status === ItemCoverageStatus.Draft
+$: itemIsDraft = isItemDraft(item)
 $: marketValueIsDisabled = !!item.id && !itemIsDraft && !isAdmin
 $: applyBtnLabel = !item.coverage_status || itemIsDraft ? 'review and checkout' : 'save changes'
 $: make,

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -7,7 +7,7 @@ import YearInput from '../YearInput.svelte'
 import { MAX_TEXT_AREA_LENGTH } from 'components/const'
 import type { AccountablePersonOptions } from 'data/accountablePersons'
 import {
-  isItemDraft,
+  itemIsDraft,
   ItemCoverageStatus,
   NewItemFormData,
   PolicyItem,
@@ -61,9 +61,9 @@ let userCustomizedStatementName = false
 
 $: country = item?.accountable_person?.country || country
 $: !$catItemsInitialized && loadCategories()
-$: itemIsDraft = isItemDraft(item)
-$: marketValueIsDisabled = !!item.id && !itemIsDraft && !isAdmin
-$: applyBtnLabel = !item.coverage_status || itemIsDraft ? 'review and checkout' : 'save changes'
+$: isDraft = itemIsDraft(item)
+$: marketValueIsDisabled = !!item.id && !isDraft && !isAdmin
+$: applyBtnLabel = !item.coverage_status || isDraft ? 'review and checkout' : 'save changes'
 $: make,
   model,
   itemDescription,

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -359,6 +359,10 @@ export const itemIsApproved = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Approved
 }
 
+export const isItemDraft = (item: PolicyItem): boolean => {
+  return item.coverage_status === ItemCoverageStatus.Draft
+}
+
 export const itemIsInactive = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Inactive
 }

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -355,7 +355,7 @@ export const itemIsApproved = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Approved
 }
 
-export const isItemDraft = (item: PolicyItem): boolean => {
+export const itemIsDraft = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Draft
 }
 

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -1,6 +1,55 @@
-import { MonthlyCutoffDay } from 'data/items'
+import { BillingPeriod, isItemDraft, itemIsApproved, MonthlyCutoffDay, PolicyItem } from 'data/items'
+import { formatDate, startOfFutureMonth } from 'helpers/dates'
+import { formatMoney } from 'helpers/money'
+
+const getMonthlyRenewalDate = (item: PolicyItem): string => {
+  if (itemIsApproved(item)) {
+    return startOfFutureMonth(1)
+  }
+
+  if (isItemDraft(item)) {
+    if (isBeforeMonthlyCutoff()) {
+      return startOfFutureMonth(1)
+    } else {
+      return startOfFutureMonth(2)
+    }
+  }
+
+  return ''
+}
+
+export const getPremiumDescription = (item: PolicyItem | undefined): string => {
+  if (!item || !item.id) {
+    return ''
+  }
+
+  if (isMonthly(item)) {
+    return `${formatMoney(item.monthly_premium)} / month`
+  }
+
+  return `${formatMoney(item.annual_premium)} / year`
+}
+
+export const getRenewalDate = (item: PolicyItem | undefined): string => {
+  if (!item || !item.id) {
+    return ''
+  }
+
+  if (isMonthly(item)) {
+    return getMonthlyRenewalDate(item)
+  }
+
+  return getYearlyRenewalDate(item)
+}
+
+const getYearlyRenewalDate = (item: PolicyItem): string => {
+  const renewYear = new Date().getFullYear() + 1
+  return formatDate(`${renewYear}-01-01`)
+}
 
 export const isBeforeMonthlyCutoff = () => {
   const today = new Date()
   return today.getUTCDate() < MonthlyCutoffDay
 }
+
+const isMonthly = (item: PolicyItem) => item.billing_period === BillingPeriod.Monthly

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -1,4 +1,4 @@
-import { BillingPeriod, isItemDraft, itemIsApproved, MonthlyCutoffDay, PolicyItem } from 'data/items'
+import { BillingPeriod, itemIsDraft, itemIsApproved, MonthlyCutoffDay, PolicyItem } from 'data/items'
 import { formatDate, isMeaningfulDateString, startOfFutureMonth } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 
@@ -7,7 +7,7 @@ const getMonthlyRenewalDate = (item: PolicyItem): string => {
     return startOfFutureMonth(1)
   }
 
-  if (isItemDraft(item)) {
+  if (itemIsDraft(item)) {
     if (isBeforeMonthlyCutoff()) {
       return startOfFutureMonth(1)
     } else {
@@ -47,7 +47,7 @@ export const getStartDate = (item: PolicyItem): string => {
     return formatDate(item.coverage_start_date)
   }
 
-  if (isItemDraft(item)) {
+  if (itemIsDraft(item)) {
     return '(when approved)'
   }
 

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -1,5 +1,5 @@
 import { BillingPeriod, isItemDraft, itemIsApproved, MonthlyCutoffDay, PolicyItem } from 'data/items'
-import { formatDate, startOfFutureMonth } from 'helpers/dates'
+import { formatDate, isMeaningfulDateString, startOfFutureMonth } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 
 const getMonthlyRenewalDate = (item: PolicyItem): string => {
@@ -43,7 +43,15 @@ export const getRenewalDate = (item: PolicyItem | undefined): string => {
 }
 
 export const getStartDate = (item: PolicyItem): string => {
-  return formatDate(item.coverage_start_date) || '(when approved)'
+  if (isMeaningfulDateString(item.coverage_start_date)) {
+    return formatDate(item.coverage_start_date)
+  }
+
+  if (isItemDraft(item)) {
+    return '(when approved)'
+  }
+
+  return ''
 }
 
 const getYearlyRenewalDate = (item: PolicyItem): string => {

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -1,0 +1,4 @@
+export const isBeforeMonthlyCutoff = () => {
+  const today = new Date()
+  return today.getUTCDate() < 20
+}

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -42,6 +42,10 @@ export const getRenewalDate = (item: PolicyItem | undefined): string => {
   return getYearlyRenewalDate(item)
 }
 
+export const getStartDate = (item: PolicyItem): string => {
+  return formatDate(item.coverage_start_date) || '(when approved)'
+}
+
 const getYearlyRenewalDate = (item: PolicyItem): string => {
   const renewYear = new Date().getFullYear() + 1
   return formatDate(`${renewYear}-01-01`)

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -8,6 +8,11 @@ export const formatFriendlyDate = (dateTimeString: string): string => {
   return formatDate(dateTimeString.split('T')[0], { month: 'numeric', day: 'numeric', year: 'numeric' })
 }
 
+/**
+ * Take a date string and format it for display to the user. If no timezone is included in the date
+ * string, UTC is assumed. Returns an empty string for date strings that probably indicate no-data
+ * (such as a date near the Unix epoch, or a date like "0001-01-01").
+ */
 export const formatDate = (
   dateString: string | undefined,
   options: Intl.DateTimeFormatOptions | undefined = { month: 'long', day: 'numeric', year: 'numeric' }
@@ -19,8 +24,13 @@ export const formatDate = (
       // if the date is within a day of the epoch assume it is the epoch since local timestring could be used
       return ''
     }
-    // When the dateString does not contain a time portion, treat it as a UTC date
+
+    if (date.toISOString() === '0001-01-01T00:00:00.000Z') {
+      return ''
+    }
+
     if (dateString.indexOf('T') === -1) {
+      // When the dateString does not contain a time portion, treat it as a UTC date
       options.timeZone = 'UTC'
     }
     return date.toLocaleDateString('default', options)

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -18,14 +18,7 @@ export const formatDate = (
   options: Intl.DateTimeFormatOptions | undefined = { month: 'long', day: 'numeric', year: 'numeric' }
 ): string => {
   if (dateString) {
-    const date = new Date(dateString)
-
-    if (Math.abs(date.getTime()) < day) {
-      // if the date is within a day of the epoch assume it is the epoch since local timestring could be used
-      return ''
-    }
-
-    if (date.toISOString() === '0001-01-01T00:00:00.000Z') {
+    if (!isMeaningfulDateString(dateString)) {
       return ''
     }
 
@@ -33,6 +26,8 @@ export const formatDate = (
       // When the dateString does not contain a time portion, treat it as a UTC date
       options.timeZone = 'UTC'
     }
+
+    const date = new Date(dateString)
     return date.toLocaleDateString('default', options)
   }
   return ''
@@ -69,4 +64,24 @@ export const formatDateAndTime = (
 export const isFourDigitYear = (year: any): boolean => {
   const fourDigitYearRegex = /^[1-9][0-9]{3}$/
   return fourDigitYearRegex.test(String(year))
+}
+
+export const isMeaningfulDateString = (dateString: string | undefined): boolean => {
+  if (!dateString) {
+    return false
+  }
+
+  const date = new Date(dateString)
+
+  if (Math.abs(date.getTime()) < day) {
+    // If the date is within a day of the epoch, assume it is the epoch since a local time string
+    // could have been used.
+    return false
+  }
+
+  if (date.toISOString() === '0001-01-01T00:00:00.000Z') {
+    return false
+  }
+
+  return true
 }

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -61,6 +61,16 @@ export const formatDateAndTime = (
   return ''
 }
 
+/**
+ * Get formatted date string for the 1st day of the specified month.
+ */
+export const startOfFutureMonth = (offsetInMonths: number = 0): string => {
+  const targetDate = new Date()
+  targetDate.setMonth(targetDate.getMonth() + offsetInMonths)
+  targetDate.setDate(1)
+  return formatDate(targetDate.toISOString())
+}
+
 export const isFourDigitYear = (year: any): boolean => {
   const fourDigitYearRegex = /^[1-9][0-9]{3}$/
   return fourDigitYearRegex.test(String(year))


### PR DESCRIPTION
### Fixed
- Fix start-date calculations used for checkout page (re: monthly vs yearly)
- Fix renewal-date calculations used for checkout page (re: monthly vs yearly)
- Fix `formatDate()` to treat Go empty-date values as not a date

### Added
- Add `getPremiumDescription()` helper
- Add `getRenewalDate()` helper
- Add `getStartDate()` helper
- Add `isBeforeMonthlyCutoff()` helper
- Add `isItemDraft()` helper
- Add `isMeaningfulDateString()` helper
- Add `isMonthly()` helper
- Add `startOfFutureMonth()` helper