### PR TITLE
CVR-736 CVR-737 Add minimum premium to checkout and update ItemCategory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,12 @@
 
   "[typescript]": {
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
+    "editor.formatOnPaste": true
   },
 
   "[svelte]": {
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": true
+    "editor.formatOnPaste": true,
+    "editor.defaultFormatter": "svelte.svelte-vscode"
   }
 }

--- a/src/components/checkout/MonthlyCheckoutMessage.svelte
+++ b/src/components/checkout/MonthlyCheckoutMessage.svelte
@@ -12,7 +12,7 @@ $: monthlyPremium = item.monthly_premium
 </script>
 
 <span>
-  {#if isBeforeMonthlyCutoff}
+  {#if isBeforeMonthlyCutoff()}
     Pay {formatMoney(monthlyPremium)} from {org} account {accountOrHouseholdId}
     each month.
   {:else}

--- a/src/components/checkout/YearlyCheckoutMessage.svelte
+++ b/src/components/checkout/YearlyCheckoutMessage.svelte
@@ -8,17 +8,24 @@ export let item: PolicyItem | undefined = undefined
 export let org: string = ''
 
 $: annualPremium = item?.annual_premium
-$: proratedAnnualPremiumOrMin = Math.max(item?.prorated_annual_premium || 0, item?.category?.minimum_premium || 0)
+$: proratedAnnualPremium = item?.prorated_annual_premium || 0
 
 $: year = new Date().getFullYear()
 $: renewYear = year + 1
 $: renewDate = formatDate(`${renewYear}-01-01`)
-$: premiumEqualsProrated = annualPremium === proratedAnnualPremiumOrMin
+$: premiumEqualsProrated = annualPremium === proratedAnnualPremium
 </script>
 
 <span>
-  Pay {formatMoney(proratedAnnualPremiumOrMin)}
-  {premiumEqualsProrated ? 'for' : 'for the remainder of'}
-  {year} from {org} account
-  {accountOrHouseholdId}. Auto-renew and pay {formatMoney(annualPremium)} on {renewDate}.
+  {#if proratedAnnualPremium > 0}
+    {#if premiumEqualsProrated}
+      Pay {formatMoney(proratedAnnualPremium)} for {year} from {org} account {accountOrHouseholdId}.
+    {:else}
+      Pay {formatMoney(proratedAnnualPremium)} for the remainder of {year} from {org} account
+      {accountOrHouseholdId}.
+    {/if}
+    Auto-renew and pay {formatMoney(annualPremium)} on {renewDate}.
+  {:else}
+    No payment needed right now. Auto-renew for {formatMoney(annualPremium)} on {renewDate}, paid from {org} account {accountOrHouseholdId}.
+  {/if}
 </span>

--- a/src/components/checkout/YearlyCheckoutMessage.svelte
+++ b/src/components/checkout/YearlyCheckoutMessage.svelte
@@ -8,17 +8,12 @@ export let item: PolicyItem | undefined = undefined
 export let org: string = ''
 
 $: annualPremium = item?.annual_premium
-$: proratedAnnualPremiumOrMin = getGreaterOfTwoValues(
-  item?.prorated_annual_premium || 0,
-  item?.category?.minimum_premium || 0
-)
+$: proratedAnnualPremiumOrMin = Math.max(item?.prorated_annual_premium || 0, item?.category?.minimum_premium || 0)
 
 $: year = new Date().getFullYear()
 $: renewYear = year + 1
 $: renewDate = formatDate(`${renewYear}-01-01`)
 $: premiumEqualsProrated = annualPremium === proratedAnnualPremiumOrMin
-
-const getGreaterOfTwoValues = (value1: number, value2: number) => (value1 > value2 ? value1 : value2)
 </script>
 
 <span>

--- a/src/components/checkout/YearlyCheckoutMessage.svelte
+++ b/src/components/checkout/YearlyCheckoutMessage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { PolicyItem } from 'data/items'
-import { formatDate, getYear } from 'helpers/dates'
+import type { PolicyItem } from 'data/items'
+import { formatDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 
 export let accountOrHouseholdId: string = ''
@@ -8,19 +8,22 @@ export let item: PolicyItem | undefined = undefined
 export let org: string = ''
 
 $: annualPremium = item?.annual_premium
-$: proratedAnnualPremium = item?.prorated_annual_premium
+$: proratedAnnualPremiumOrMin = getGreaterOfTwoValues(
+  item?.prorated_annual_premium || 0,
+  item?.category?.minimum_premium || 0
+)
 
-$: year = (new Date()).getFullYear()
+$: year = new Date().getFullYear()
 $: renewYear = year + 1
 $: renewDate = formatDate(`${renewYear}-01-01`)
+$: premiumEqualsProrated = annualPremium === proratedAnnualPremiumOrMin
+
+const getGreaterOfTwoValues = (value1: number, value2: number) => (value1 > value2 ? value1 : value2)
 </script>
 
 <span>
-  {#if proratedAnnualPremium > 100}
-    Pay {formatMoney(proratedAnnualPremium)} for the remainder of {year} from {org} account
-    {accountOrHouseholdId}. Auto-renew and pay {formatMoney(annualPremium)} on {renewDate}.
-  {:else}
-    No payment needed right now. Auto-renew for {formatMoney(annualPremium)} on {renewDate},
-    paid from {org} account {accountOrHouseholdId}.
-  {/if}
+  Pay {formatMoney(proratedAnnualPremiumOrMin)}
+  {premiumEqualsProrated ? 'for' : 'for the remainder of'}
+  {year} from {org} account
+  {accountOrHouseholdId}. Auto-renew and pay {formatMoney(annualPremium)} on {renewDate}.
 </span>

--- a/src/data/itemCategories.ts
+++ b/src/data/itemCategories.ts
@@ -3,12 +3,15 @@ import { writable } from 'svelte/store'
 import type { RiskCategory } from './items'
 
 export type ItemCategory = {
+  billing_period: number /*Number of months*/
   created_at: string /*Date*/
   help_text: string
   key: string
   id: string
   minimum_deductible: number
+  minimum_premium: number
   name: string
+  premium_factor: string
   require_make_model: boolean
   risk_category: RiskCategory
   updated_at: string /*Date*/

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,6 +1,7 @@
 import { CREATE, DELETE, GET, UPDATE } from '.'
 import { throwError } from '../error'
 import { convertToCents } from 'helpers/money'
+import type { ItemCategory } from './itemCategories'
 import { selectedPolicyId } from './role-policy-selection'
 import { derived, get, writable } from 'svelte/store'
 
@@ -61,7 +62,7 @@ export type PolicyItem = {
   accountable_person: AccountablePerson
   annual_premium: number
   billing_period: number /* in months, e.g. 1 or 12 */
-  category: any /*ItemCategory*/
+  category: ItemCategory
   country: string
   coverage_amount: number
   coverage_end_date: string /*Date*/
@@ -152,7 +153,7 @@ export const selectedPolicyItems = derived(
   [itemsByPolicyId, selectedPolicyId],
   ([$itemsByPolicyId, $selectedPolicyId]) => {
     return $itemsByPolicyId[$selectedPolicyId] || []
-  }
+  },
 )
 
 /**

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -39,7 +39,7 @@ export const getRenewalDate = (item: PolicyItem | undefined): string => {
     return getMonthlyRenewalDate(item)
   }
 
-  return getYearlyRenewalDate(item)
+  return getYearlyRenewalDate()
 }
 
 export const getStartDate = (item: PolicyItem): string => {
@@ -54,12 +54,12 @@ export const getStartDate = (item: PolicyItem): string => {
   return ''
 }
 
-const getYearlyRenewalDate = (item: PolicyItem): string => {
+const getYearlyRenewalDate = (): string => {
   const renewYear = new Date().getFullYear() + 1
   return formatDate(`${renewYear}-01-01`)
 }
 
-export const isBeforeMonthlyCutoff = () => {
+export const isBeforeMonthlyCutoff = (): boolean => {
   const today = new Date()
   return today.getUTCDate() < MonthlyCutoffDay
 }

--- a/src/helpers/money.ts
+++ b/src/helpers/money.ts
@@ -6,6 +6,9 @@ export const convertToCents = (dollars?: number | string): number => {
 }
 
 export const formatMoney = (cents: number | undefined): string => {
+  if (cents === undefined) {
+    return ''
+  }
   if (!cents || !Number.isFinite(+cents)) {
     return '$0.00'
   }

--- a/src/helpers/money.ts
+++ b/src/helpers/money.ts
@@ -5,7 +5,7 @@ export const convertToCents = (dollars?: number | string): number => {
   return Math.round(Number(dollars) * 100) // Round to avoid #'s like 7001.000000000001
 }
 
-export const formatMoney = (cents: number): string => {
+export const formatMoney = (cents: number | undefined): string => {
   if (!cents || !Number.isFinite(+cents)) {
     return '$0.00'
   }


### PR DESCRIPTION
[CVR-736](https://itse.youtrack.cloud/issue/CVR-736/Update-UI-to-reflect-the-minimum-premium)
[CVR-737](https://itse.youtrack.cloud/issue/CVR-737/Update-UI-logic-to-reflect-that-the-minimum-premium-applies-to-both-the-annual-premium-and-the-prorated-annual-premium)

# Fixed
- prettier not formatting again
- isBeforeMonthlyCutoff value was being used
- ts errors

## Added
- ItemCategory to PolicyItem

## Changed
- Yearly checkout message to show minimum and always show payment
![image](https://github.com/silinternational/cover-ui/assets/70765247/9bdd5c80-6259-4bfa-995b-635a1e767cf5)
