### PR TITLE
CVR-705 (d): Update the Items Table re: monthly vs yearly billing periods

### DIFF
--- a/src/components/Datatable/PolicyItems/ItemsTable.svelte
+++ b/src/components/Datatable/PolicyItems/ItemsTable.svelte
@@ -5,6 +5,7 @@ import CopyTableButton from '../CopyTableButton.svelte'
 import { ClaimItem, incompleteClaimItemStatuses, selectedPolicyClaims } from 'data/claims'
 import { getItemState } from 'data/states'
 import { AccountablePerson, editableCoverageStatuses, ItemCoverageStatus, PolicyItem } from 'data/items'
+import { isMonthly } from 'helpers/coverage'
 import { formatDate, formatFriendlyDate } from 'helpers/dates'
 import { getItemIcon, hasEnded, willEnd } from './itemTableHelpers'
 import { throwError } from '../../../error'
@@ -316,7 +317,14 @@ const getStatusClass = (status: ItemCoverageStatus) =>
         <RowItem status={item.coverage_status}>{item.accountable_person?.name || ''}</RowItem>
         <RowItem status={item.coverage_status}>{item.accountable_person?.country || item.country || ''}</RowItem>
         <RowItem status={item.coverage_status} numeric>{formatMoney(item.coverage_amount)}</RowItem>
-        <RowItem status={item.coverage_status} numeric>{formatMoney(item.annual_premium)}</RowItem>
+        <RowItem status={item.coverage_status} numeric>
+          {formatMoney(item.annual_premium)}
+          {#if isMonthly(item)}
+            <div>
+              <small class="tw-opacity-60">({formatMoney(item.monthly_premium)}/month)</small>
+            </div>
+          {/if}
+        </RowItem>
         <RowItem status={item.coverage_status}>{formatDate(item.updated_at)}</RowItem>
         <RowItem>
           <IconButton icon="more_vert" on:click={() => handleMoreVertClick(item.id)} />

--- a/src/components/Datatable/PolicyItems/ItemsTable.svelte
+++ b/src/components/Datatable/PolicyItems/ItemsTable.svelte
@@ -84,7 +84,7 @@ const columns: Column[] = [
     title: 'Premium',
     headerId: 'premium',
     numeric: true,
-    path: 'prorated_annual_premium',
+    path: 'annual_premium',
     sortable: true,
   },
   {

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -64,4 +64,4 @@ export const isBeforeMonthlyCutoff = () => {
   return today.getUTCDate() < MonthlyCutoffDay
 }
 
-const isMonthly = (item: PolicyItem) => item.billing_period === BillingPeriod.Monthly
+export const isMonthly = (item: PolicyItem) => item.billing_period === BillingPeriod.Monthly


### PR DESCRIPTION
### Fixed
- When sorting by premium, use the field being displayed 
  * Previously it was sorting by `prorated_annual_premium`, but displaying `annual_premium`. If that was intentional, please let me know.

### Added
- For items billed monthly, show that in the Items Table

<img width="284" alt="Screenshot 2023-10-09 at 3 07 01 PM" src="https://github.com/silinternational/cover-ui/assets/6233204/7b6cfbec-8827-4537-854b-0448db5f8ab8">

---

I wrestled a little bit with various ways to handle showing annual vs. monthly premiums. This approach seems to work, since it both (A) visually indicates which are paid monthly, and what that monthy amount is, and (B) still shows the annual premium so that sorting the table by the Premium column still produces results that make sense (since the primary number shown is the annual premium, even for items billed monthly).