### PR TITLE
CVR-705 Add monthly premiums to policy page

### DIFF
--- a/src/components/InfoDialog.svelte
+++ b/src/components/InfoDialog.svelte
@@ -1,0 +1,18 @@
+<script>
+import { Dialog } from '@silintl/ui-components'
+
+export let infoIsOpen = false
+export let title = ''
+</script>
+
+<Dialog.Alert
+  open={infoIsOpen}
+  buttons={[{ label: 'Ok', action: 'cancel', class: 'mdc-dialog__button' }]}
+  defaultAction="cancel"
+  {title}
+  titleIcon="info"
+  on:closed={() => (infoIsOpen = false)}
+  on:closed
+>
+  <slot />
+</Dialog.Alert>

--- a/src/components/InfoDialog.svelte
+++ b/src/components/InfoDialog.svelte
@@ -11,7 +11,6 @@ export let title = ''
   defaultAction="cancel"
   {title}
   titleIcon="info"
-  on:closed={() => (infoIsOpen = false)}
   on:closed
 >
   <slot />

--- a/src/components/InfoModal.svelte
+++ b/src/components/InfoModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { Dialog, IconButton } from '@silintl/ui-components'
+import { InfoDialog } from '.'
 
 export let content = ''
 export let title = ''
@@ -12,6 +13,6 @@ const buttons: Dialog.AlertButton[] = [{ label: 'Ok', action: 'cancel', class: '
 {#if hasInfoButton}
   <IconButton class="gray" icon="info" on:click={() => (open = true)} />
 {/if}
-<Dialog.Alert {open} {buttons} defaultAction="cancel" {title} titleIcon="info" on:closed={() => (open = false)}>
+<InfoDialog infoIsOpen={open} {title} on:closed={() => (open = false)}>
   {content}
-</Dialog.Alert>
+</InfoDialog>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ import FileLink from './FileLink.svelte'
 import { FilePreview } from './FilePreview'
 import FilePreviews from './FilePreview'
 import InfoModal from './InfoModal.svelte'
+import InfoDialog from './InfoDialog.svelte'
 import ItemBanner from './banners/ItemBanner.svelte'
 import ItemDeleteModal from './ItemDeleteModal.svelte'
 import ItemDetails from './ItemDetails.svelte'
@@ -59,6 +60,7 @@ export {
   FilePreview,
   FilePreviews,
   InfoModal,
+  InfoDialog,
   ItemBanner,
   ItemDeleteModal,
   ItemDetails,

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Breadcrumb, CardsGrid, ClaimsTable, ItemsTable, Row, Strikes, CustomerReport } from 'components'
+import { Breadcrumb, CardsGrid, ClaimsTable, InfoDialog, ItemsTable, Row, Strikes, CustomerReport } from 'components'
 import { isLoadingById, loading } from 'components/progress'
 import CopyTableButton from '../../components/Datatable/CopyTableButton.svelte'
 import { Claim, claimIsOpen, loadClaimsByPolicyId, selectedPolicyClaims } from 'data/claims'
@@ -27,7 +27,16 @@ import {
   settingsPolicy,
 } from 'helpers/routes'
 import { goto, metatags } from '@roxi/routify'
-import { Button, Checkbox, Datatable, isAboveMobile, isAboveTablet, Page, Switch } from '@silintl/ui-components'
+import {
+  Button,
+  Checkbox,
+  Datatable,
+  IconButton,
+  isAboveMobile,
+  isAboveTablet,
+  Page,
+  Switch,
+} from '@silintl/ui-components'
 import { generateRandomID } from '@silintl/ui-components/random'
 import { onMount } from 'svelte'
 
@@ -36,6 +45,7 @@ export let policyId: string
 let policy = {} as Policy
 let showAllClaims = false
 let hideInactive = false
+let infoIsOpen = false
 const uniqueTableClass = generateRandomID('items-table-')
 
 onMount(() => {
@@ -63,6 +73,7 @@ $: policyName = getNameOfPolicy(policy)
 $: policyName && (metatags.title = formatPageTitle(`Policies > ${policyName}`))
 $: coverage = formatMoney(approvedItems.reduce((sum, item) => sum + item.coverage_amount, 0))
 $: premium = formatMoney(approvedItems.reduce((sum, item) => sum + item.annual_premium, 0))
+$: monthlyPremiumTotal = formatMoney(approvedItems.reduce((sum, item) => sum + item.monthly_premium, 0))
 $: entityCode = policy.entity_code?.code
 $: numberOfItemsNotShown = items.length - itemsForTable.length
 $: gotoItemsBtnLabel = `View ${numberOfItemsNotShown} more items…`
@@ -138,6 +149,10 @@ section:not(:first-child) {
     justify-content: start;
   }
 }
+dt,
+dd {
+  height: 1.7rem;
+}
 .main-header h1 {
   grid-column: 1 / -1;
 }
@@ -185,8 +200,15 @@ section:not(:first-child) {
       <dl>
         <dt>Coverage</dt>
         <dd>{coverage}</dd>
-        <dt>Premium</dt>
+        <dt>Yearly Premium</dt>
         <dd>{premium} per year</dd>
+        <dt class="tw-flex tw-items-center">
+          <span> Monthly Premium</span>
+          <IconButton class="gray" icon="info" on:click={() => (infoIsOpen = true)} />
+        </dt>
+        <dd>
+          {monthlyPremiumTotal} per month
+        </dd>
         <dt>Last Updated</dt>
         <dd>{formatFriendlyDate(policy.updated_at)}</dd>
       </dl>
@@ -296,4 +318,8 @@ section:not(:first-child) {
   </section>
 
   <div class="p-2" />
+
+  <InfoDialog {infoIsOpen} title="Monthly Premiums" on:closed={() => (infoIsOpen = false)}>
+    Only some premiums are billed monthly (e.g. vehicles). Most are billed Annually.
+  </InfoDialog>
 </Page>

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -72,8 +72,11 @@ $: openClaimCount = recentClaims.filter(claimIsOpen).length
 $: policyName = getNameOfPolicy(policy)
 $: policyName && (metatags.title = formatPageTitle(`Policies > ${policyName}`))
 $: coverage = formatMoney(approvedItems.reduce((sum, item) => sum + item.coverage_amount, 0))
-$: premium = formatMoney(approvedItems.reduce((sum, item) => sum + item.annual_premium, 0))
-$: monthlyPremiumTotal = formatMoney(approvedItems.reduce((sum, item) => sum + item.monthly_premium, 0))
+$: premium = formatMoney(
+  approvedItems.reduce((sum, item) => (item.billing_period === 1 ? sum : sum + item.annual_premium), 0)
+)
+$: monthlyPremiumsSum = approvedItems.reduce((sum, item) => sum + item.monthly_premium, 0)
+$: monthlyPremiumSumsString = formatMoney(monthlyPremiumsSum)
 $: entityCode = policy.entity_code?.code
 $: numberOfItemsNotShown = items.length - itemsForTable.length
 $: gotoItemsBtnLabel = `View ${numberOfItemsNotShown} more items…`
@@ -202,13 +205,15 @@ dd {
         <dd>{coverage}</dd>
         <dt>Yearly Premium</dt>
         <dd>{premium} per year</dd>
-        <dt class="tw-flex tw-items-center">
-          <span> Monthly Premium</span>
-          <IconButton class="gray" icon="info" on:click={() => (infoIsOpen = true)} />
-        </dt>
-        <dd>
-          {monthlyPremiumTotal} per month
-        </dd>
+        {#if monthlyPremiumsSum}
+          <dt class="tw-flex tw-items-center">
+            <span> Monthly Premium</span>
+            <IconButton class="gray" icon="info" on:click={() => (infoIsOpen = true)} />
+          </dt>
+          <dd>
+            {monthlyPremiumSumsString} per month
+          </dd>
+        {/if}
         <dt>Last Updated</dt>
         <dd>{formatFriendlyDate(policy.updated_at)}</dd>
       </dl>


### PR DESCRIPTION
[CVR-705](https://itse.youtrack.cloud/issue/CVR-705/Update-UI-to-handle-monthly-vs-yearly-premiums)
## Added
- Added InfoDialog
- Added Monthly Premium (sum of all) to policy details

![image](https://github.com/silinternational/cover-ui/assets/70765247/68d17288-771a-4582-9662-99a1eaf3ec56)
