### PR TITLE
CVR-747: Use "coverage value" not "market value" in validation message

### DIFF
--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -62,7 +62,7 @@ let userCustomizedStatementName = false
 $: country = item?.accountable_person?.country || country
 $: !$catItemsInitialized && loadCategories()
 $: isDraft = itemIsDraft(item)
-$: marketValueIsDisabled = !!item.id && !isDraft && !isAdmin
+$: coverageAmountIsDisabled = !!item.id && !isDraft && !isAdmin
 $: applyBtnLabel = !item.coverage_status || isDraft ? 'review and checkout' : 'save changes'
 $: make,
   model,
@@ -253,7 +253,7 @@ const setInitialValues = (user: User, item: PolicyItem) => {
     <MoneyInput
       label="Coverage value (USD)"
       bind:value={coverageAmountUSD}
-      disabled={marketValueIsDisabled}
+      disabled={coverageAmountIsDisabled}
     />
     <Description>
       <ConvertCurrencyLink />

--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -41,7 +41,7 @@ const dispatch = createEventDispatcher<{
 let accountablePersonId = ''
 let categoryId = ''
 let country = ''
-let marketValueUSD: number | string | undefined
+let coverageAmountUSD: number | string | undefined
 let coverageStatus: ItemCoverageStatus
 let itemDescription = ''
 let inStorage = false
@@ -68,7 +68,7 @@ $: make,
   model,
   itemDescription,
   uniqueIdentifier,
-  marketValueUSD,
+  coverageAmountUSD,
   year,
   accountablePersonId && categoryId && name && debouncedSave()
 $: selectedCategory = $categories.find((c) => c.id === categoryId)
@@ -92,7 +92,7 @@ const getFormData = (): NewItemFormData => {
     accountablePersonId,
     categoryId,
     country,
-    marketValueUSD,
+    coverageAmountUSD,
     coverageStatus,
     itemDescription,
     inStorage,
@@ -158,7 +158,7 @@ const setInitialValues = (user: User, item: PolicyItem) => {
   accountablePersonId = item.accountable_person?.id || user.id
   categoryId = item.category?.id || categoryId
   country = item.country || country
-  marketValueUSD = Number.isInteger(item.coverage_amount) ? String(item.coverage_amount / 100) : undefined
+  coverageAmountUSD = Number.isInteger(item.coverage_amount) ? String(item.coverage_amount / 100) : undefined
   coverageStatus = item.coverage_status || coverageStatus
   itemDescription = item.description || itemDescription
   inStorage = typeof item.in_storage === 'boolean' ? item.in_storage : false
@@ -252,7 +252,7 @@ const setInitialValues = (user: User, item: PolicyItem) => {
   <div>
     <MoneyInput
       label="Coverage value (USD)"
-      bind:value={marketValueUSD}
+      bind:value={coverageAmountUSD}
       disabled={marketValueIsDisabled}
     />
     <Description>

--- a/src/components/forms/items/itemFormHelpers.ts
+++ b/src/components/forms/items/itemFormHelpers.ts
@@ -24,10 +24,10 @@ export const validateForSave = (formData: NewItemFormData | UpdateItemFormData):
 
 export const validateForSubmit = (item: PolicyItem, formData: NewItemFormData | UpdateItemFormData, isVehicle: boolean): void => {
   validateForSave(formData)
-  assertIsLessOrEqual(0.01, Number(formData.marketValueUSD), 'Please specify the coverage value')
+  assertIsLessOrEqual(0.01, Number(formData.coverageAmountUSD), 'Please specify the coverage value')
   item.coverage_status !== ItemCoverageStatus.Draft &&
     assertIsLessOrEqual(
-      Number(formData.marketValueUSD) * 100,
+      Number(formData.coverageAmountUSD) * 100,
       item.coverage_amount,
       'Coverage amount cannot be increased'
     )

--- a/src/components/forms/items/itemFormHelpers.ts
+++ b/src/components/forms/items/itemFormHelpers.ts
@@ -24,7 +24,7 @@ export const validateForSave = (formData: NewItemFormData | UpdateItemFormData):
 
 export const validateForSubmit = (item: PolicyItem, formData: NewItemFormData | UpdateItemFormData, isVehicle: boolean): void => {
   validateForSave(formData)
-  assertIsLessOrEqual(0.01, Number(formData.marketValueUSD), 'Please specify the market value')
+  assertIsLessOrEqual(0.01, Number(formData.marketValueUSD), 'Please specify the coverage value')
   item.coverage_status !== ItemCoverageStatus.Draft &&
     assertIsLessOrEqual(
       Number(formData.marketValueUSD) * 100,

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -123,7 +123,7 @@ export interface ItemFormData {
   accountablePersonId: string /*UUID*/
   categoryId: string
   country?: string
-  marketValueUSD?: number | string
+  coverageAmountUSD?: number | string
   itemDescription?: string
   inStorage?: boolean
   make?: string
@@ -186,7 +186,7 @@ export async function addItem(policyId: string, itemData: NewItemFormData): Prom
     accountable_person_id: itemData.accountablePersonId,
     category_id: itemData.categoryId,
     country: itemData.country,
-    coverage_amount: convertToCents(itemData.marketValueUSD),
+    coverage_amount: convertToCents(itemData.coverageAmountUSD),
     coverage_status: itemData.coverageStatus,
     description: itemData.itemDescription,
     in_storage: itemData.inStorage,
@@ -276,7 +276,7 @@ export async function updateItem(policyId: string, itemId: string, itemData: Upd
     accountable_person_id: itemData.accountablePersonId,
     category_id: itemData.categoryId,
     country: itemData.country,
-    coverage_amount: convertToCents(itemData.marketValueUSD),
+    coverage_amount: convertToCents(itemData.coverageAmountUSD),
     description: itemData.itemDescription,
     in_storage: itemData.inStorage,
     make: itemData.make,
@@ -370,7 +370,7 @@ export const assignItems = (newMemberId: string, policyId: string, selectedPolic
     updateItem(policyId, item.id, {
       categoryId: item.category.id,
       accountablePersonId: newMemberId,
-      marketValueUSD: item.coverage_amount / 100,
+      coverageAmountUSD: item.coverage_amount / 100,
       itemDescription: item.description,
       inStorage: item.in_storage,
       make: item.make,
@@ -387,7 +387,7 @@ export const parseItemForAddItem = (item: PolicyItem): NewItemFormData => {
     accountablePersonId: item.accountable_person.id,
     categoryId: item.category.id,
     country: item.country || item.accountable_person.country,
-    marketValueUSD: item.coverage_amount / 100,
+    coverageAmountUSD: item.coverage_amount / 100,
     itemDescription: item.description,
     inStorage: item.in_storage,
     make: item.make,


### PR DESCRIPTION
### Fixed
- Use "coverage value" not "market value" in validation message
- Rename ItemForm-related `marketValueUSD` to `coverageAmountUSD` 