### PR TITLE
CVR-749: Fix display of "Starts" and "Renews" fields when monthly approval is pending

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -364,6 +364,10 @@ export const itemIsInactive = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Inactive
 }
 
+export const itemIsPending = (item: PolicyItem): boolean => {
+  return item.coverage_status === ItemCoverageStatus.Pending
+}
+
 export const assignItems = (newMemberId: string, policyId: string, selectedPolicyMemberId: string): void => {
   const items = getItemsAccountablePersonIsOn(selectedPolicyMemberId, policyId)
   items.forEach((item) => {

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -7,7 +7,7 @@ const getMonthlyRenewalDate = (item: PolicyItem): string => {
     return startOfFutureMonth(1)
   }
 
-  if (itemIsDraft(item)) {
+  if (itemIsDraft(item) || itemIsPending(item)) {
     if (isBeforeMonthlyCutoff()) {
       return startOfFutureMonth(1)
     } else {

--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -1,4 +1,4 @@
-import { BillingPeriod, itemIsDraft, itemIsApproved, MonthlyCutoffDay, PolicyItem } from 'data/items'
+import { BillingPeriod, itemIsDraft, itemIsApproved, itemIsPending, MonthlyCutoffDay, PolicyItem } from 'data/items'
 import { formatDate, isMeaningfulDateString, startOfFutureMonth } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 
@@ -47,7 +47,7 @@ export const getStartDate = (item: PolicyItem): string => {
     return formatDate(item.coverage_start_date)
   }
 
-  if (itemIsDraft(item)) {
+  if (itemIsDraft(item) || itemIsPending(item)) {
     return '(when approved)'
   }
 


### PR DESCRIPTION
### Fixed
- Show "when approved" as start date if an item's status is Pending (not just Draft)
- Show renewal date for monthly items with a status of Pending (not just Draft)