### PR TITLE
Fix the condition for when to show the Delete button on an Item Form

### DIFF
--- a/src/components/forms/ItemForm.svelte
+++ b/src/components/forms/ItemForm.svelte
@@ -279,7 +279,7 @@ const setInitialValues = (user: User, item: PolicyItem) => {
   </div>
   <p>
     <Button outlined on:click={saveForLater}>Save for later</Button>
-    {#if itemIsDraft}
+    {#if isDraft}
       <Button outlined on:click={onDelete}>Delete</Button>
       <ItemDeleteModal {open} {item} on:closed={handleDialog} />
     {/if}


### PR DESCRIPTION
### Fixed
- Fix the condition for when to show the Delete button on an Item Form

---

I once again tested a function instead of calling it. I think this was leftover from a rename I did, where I apparently missed this occurrence.