### PR TITLE
Fix monthly premium total

### DIFF
--- a/src/helpers/coverage.ts
+++ b/src/helpers/coverage.ts
@@ -65,3 +65,4 @@ export const isBeforeMonthlyCutoff = (): boolean => {
 }
 
 export const isMonthly = (item: PolicyItem) => item.billing_period === BillingPeriod.Monthly
+export const isYearly = (item: PolicyItem) => item.billing_period === BillingPeriod.Yearly

--- a/src/pages/policies/[policyId].svelte
+++ b/src/pages/policies/[policyId].svelte
@@ -72,11 +72,13 @@ $: openClaimCount = recentClaims.filter(claimIsOpen).length
 $: policyName = getNameOfPolicy(policy)
 $: policyName && (metatags.title = formatPageTitle(`Policies > ${policyName}`))
 $: coverage = formatMoney(approvedItems.reduce((sum, item) => sum + item.coverage_amount, 0))
-$: premium = formatMoney(
+
+$: annualPremium = formatMoney(
   approvedItems.reduce((sum, item) => (item.billing_period === 1 ? sum : sum + item.annual_premium), 0)
 )
 $: monthlyPremiumsSum = approvedItems.reduce((sum, item) => sum + item.monthly_premium, 0)
 $: monthlyPremiumSumsString = formatMoney(monthlyPremiumsSum)
+
 $: entityCode = policy.entity_code?.code
 $: numberOfItemsNotShown = items.length - itemsForTable.length
 $: gotoItemsBtnLabel = `View ${numberOfItemsNotShown} more items…`
@@ -204,7 +206,7 @@ dd {
         <dt>Coverage</dt>
         <dd>{coverage}</dd>
         <dt>Yearly Premium</dt>
-        <dd>{premium} per year</dd>
+        <dd>{annualPremium} per year</dd>
         {#if monthlyPremiumsSum}
           <dt class="tw-flex tw-items-center">
             <span> Monthly Premium</span>


### PR DESCRIPTION
[CVR-761](https://itse.youtrack.cloud/issue/CVR-761) Fix monthly premium total

---

### Fixed
- Fix monthly premium total on Policy details page

---

When running it locally, I was seeing a monthly premium of $13.33 that should have been $12.50. On further inspection, it looks like even annually-billed items (at least sometimes) have a monthly_premium value.

Breaking it out to get the lists of (approved) annual and monthly items first, then summing them, seems to have fixed it.