### PR TITLE
show dates like in table CVR-667

### DIFF
--- a/src/components/ItemDetails.svelte
+++ b/src/components/ItemDetails.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import ItemBanner from './banners/ItemBanner.svelte'
 import MessageBanner from './banners/MessageBanner.svelte'
-import { ItemCoverageStatus, PolicyItem } from 'data/items'
+import { ItemCoverageStatus, PolicyItem, itemIsDenied, itemIsNotInactive } from 'data/items'
 import { getPolicyById, loadPolicy, policies, Policy, PolicyType } from 'data/policies'
 import { getPremiumDescription, getRenewalDate, getStartDate } from 'helpers/coverage'
-import { formatDate } from 'helpers/dates'
+import { dateIsInThePast, formatDate } from 'helpers/dates'
 import { formatMoney } from 'helpers/money'
 import InfoBoxModal from './InfoBoxModal.svelte'
 import { formatDistanceToNow } from 'date-fns'
@@ -177,9 +177,14 @@ section {
         {/each}
       </dl>
     {/each}
-    <dt>Starts</dt>
+    <dt>{dateIsInThePast(item.coverage_end_date) ? 'Started' : 'Starts'}</dt>
     <dd class="value">{startDate || '—'}</dd>
-    <dt>{endDate ? 'Ends' : 'Renews'}</dt>
-    <dd class="value">{endDate || renewDate || '—'}</dd>
+    {#if endDate}
+      <dt>{dateIsInThePast(item.coverage_end_date) ? 'Ended' : 'Ends'}</dt>
+      <dd class="value">{endDate}</dd>
+    {:else if renewDate && itemIsNotInactive(item) && !itemIsDenied(item)}
+      <dt>Renews</dt>
+      <dd class="value">{renewDate}</dd>
+    {/if}
   </section>
 </div>

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -368,6 +368,10 @@ export const itemIsPending = (item: PolicyItem): boolean => {
   return item.coverage_status === ItemCoverageStatus.Pending
 }
 
+export const itemIsDenied = (item: PolicyItem): boolean => {
+  return item.coverage_status === ItemCoverageStatus.Denied
+}
+
 export const assignItems = async (
   newMemberId: string,
   policyId: string,

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -95,3 +95,8 @@ export const isMeaningfulDateString = (dateString: string | undefined): boolean 
 
   return true
 }
+
+export const dateIsInThePast = (dateString: string): boolean => {
+  const date = new Date(dateString)
+  return date < new Date()
+}


### PR DESCRIPTION
### Fixed
- Fix possilby showing renew dates on Inactive items
- show date information more consistently like in ItemsTable

[CVR-667](https://itse.youtrack.cloud/issue/CVR-667)
![image](https://github.com/silinternational/cover-ui/assets/70765247/ceb1b97c-ba32-42e2-929d-788e78294931)
![image](https://github.com/silinternational/cover-ui/assets/70765247/0b48ce62-b909-4a72-93dc-fc3777a26592)

