### PR TITLE
add hide/show policies menu button CVR-50

### DIFF
--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -46,7 +46,7 @@ let menuItems: MenuItem[]
 let myTeamPolicies: Policy[]
 let myHouseholdPolicies: Policy[]
 let roleEntries: MenuItem[]
-let areInactivePoliciesHidden = true
+let areInactivePoliciesHidden = false
 
 $: myTeamPolicies = myPolicies.filter(isTeamPolicy)
 $: myHouseholdPolicies = myPolicies.filter(isHouseholdPolicy)

--- a/src/components/RoleAndPolicyMenu.svelte
+++ b/src/components/RoleAndPolicyMenu.svelte
@@ -76,7 +76,7 @@ const selectUserPolicy = (policyId: string) => {
 }
 
 const getTeamPolicyEntries = (policies: Policy[]): MenuItem[] => {
-  const policyItems = policies.map((policy: Policy): MenuItem => {
+  const policyListItems = policies.map((policy: Policy): MenuItem => {
     return {
       icon: TEAM_POLICY_ICON,
       label: getTruncatedNameOfPolicy(policy, 18),
@@ -84,19 +84,19 @@ const getTeamPolicyEntries = (policies: Policy[]): MenuItem[] => {
       isInactive: isOlderThanDays(policy.updated_at, 30),
     }
   })
-  return [{ subtitle: 'Team Policies' }, ...policyItems]
+  return [{ subtitle: 'Team Policies' }, ...policyListItems]
 }
 
 const getHouseholdEntries = (policies: Policy[]): MenuItem[] => {
-  const policyItems = policies.map((policy): MenuItem => {
+  const policyListItems = policies.map((policy): MenuItem => {
     return {
       icon: HOUSEHOLD_POLICY_ICON,
       label: getTruncatedNameOfPolicy(policy, 18) || 'Household',
       action: () => selectUserPolicy(policy.id),
-      isInactive: isOlderThanDays(policy.updated_at, 30),
+      isInactive: false,
     }
   })
-  return [{ subtitle: 'Personal Policy' }, ...policyItems]
+  return [{ subtitle: 'Personal Policy' }, ...policyListItems]
 }
 
 const selectRole = (role: UserAppRole) => {

--- a/src/components/mdc/types/MenuItem.ts
+++ b/src/components/mdc/types/MenuItem.ts
@@ -4,4 +4,5 @@ export class MenuItem {
   url?: string
   subtitle?: string
   action?: VoidFunction
+  isInactive?: boolean
 }

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -108,3 +108,10 @@ export const isItemActiveByDates = (item: PolicyItem): boolean => {
   const end = item.coverage_end_date ? new Date(item.coverage_end_date) : new Date()
   return start <= today && today <= end
 }
+
+export const isOlderThanDays = (dateString: string, days: number): boolean => {
+  const date = new Date(dateString)
+  const today = new Date()
+  const diff = today.getTime() - date.getTime()
+  return diff > days * day
+}


### PR DESCRIPTION
### Added

- a button in the `RoleAndPolicyMenu` to hide or show policies that have not been updated 30 days

### Feature branch checklist

- [x] Documentation (README, etc.)
- [x] Run `make format`, `make lint` and `make check`

[CVR-50](https://itse.youtrack.cloud/issue/CVR-50)

![image](https://github.com/silinternational/cover-ui/assets/70765247/7624ddc3-b9ce-4424-81d7-95fd1c1a7c8b)

default menu shows all policies
![image](https://github.com/silinternational/cover-ui/assets/70765247/ef5d8b19-751f-419e-896c-196cf4bd386e)
