### PR TITLE
open download in own tab to fix bad request CVR-666

### DIFF
--- a/src/components/FileLink.svelte
+++ b/src/components/FileLink.svelte
@@ -15,4 +15,4 @@ $: expiration && setTimeout(() => (expired = true), expiration - Number(new Date
 $: expired && dispatch('expired')
 </script>
 
-<a href={url}>{filename}</a>
+<a target="_blank" href={url}>{filename}</a>


### PR DESCRIPTION

### Fixed

- fix failed render by opening file download in separate tab

[CVR-666](https://itse.youtrack.cloud/issue/CVR-666)

### Feature branch checklist

- [ ] Documentation (README, etc.)
- [ ] Run `make format`, `make lint` and `make check`
